### PR TITLE
Add Model Visualization Methods

### DIFF
--- a/nrel/routee/powertrain/core/model.py
+++ b/nrel/routee/powertrain/core/model.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 import json
 from math import isinf
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TYPE_CHECKING, Union
 from urllib import request
 
 import pandas as pd
@@ -26,6 +26,9 @@ from nrel.routee.powertrain.validation.feature_visualization import (
     visualize_features,
 )
 from nrel.routee.powertrain.validation.errors import ModelErrors
+
+if TYPE_CHECKING:
+    from pandas import Series
 
 REGISTERED_ESTIMATORS = {
     "ONNXEstimator": ONNXEstimator,
@@ -185,9 +188,22 @@ class Model:
     def visualize_features(
         self,
         estimator_id: str,
-        output_path: Optional[str] = None,
         n_samples: Optional[int] = 100,
-    ):
+        output_path: Optional[str] = None,
+        return_predictions: Optional[bool] = False,
+    ) -> Optional[Dict[str, "Series"]]:
+        """
+        generates test links to independently test the model's features
+        and creates plots of those predictions for the given estimator id
+
+        Args:
+            estimator_id: the estimator id for generating the plots
+            n_samples: the number of samples used to generate the plots
+            output_path: an optional path to save the plots as png files.
+            return_predictions: if true, returns the dictionary containing the prediction values
+
+        Returns: optionally returns a dictionary containing the predictions where the key is the feature tested
+        """
         feature_set = self.metadata.config.get_feature_set(
             feature_id_to_names(estimator_id)
         )
@@ -210,17 +226,33 @@ class Model:
             }
 
         return visualize_features(
-            model=self, feature_ranges=feature_ranges, output_path=output_path
+            model=self,
+            feature_ranges=feature_ranges,
+            output_path=output_path,
+            return_predictions=return_predictions,
         )
 
     def contour(
         self,
+        estimator_id: str,
         x_feature: str,
         y_feature: str,
-        estimator_id: str,
-        output_path: Optional[str] = None,
         n_samples: Optional[int] = 100,
+        output_path: Optional[str] = None,
     ):
+        """
+        generates a contour plot of the two test features: x_feature and y_feature.
+        for the given estimator id
+
+        Args:
+            estimator_id: the estimator id for generating the plots
+            x_feature: one of the features used to generate the energy matrix
+                and will be the x-axis feature
+            y_feature: one of the features used to generate the energy matrix
+                and will be the y-axis feature
+            n_samples: the number of samples used to generate the plots
+            output_path: an optional path to save the plots as png files.
+        """
         feature_set = self.metadata.config.get_feature_set(
             feature_id_to_names(estimator_id)
         )

--- a/nrel/routee/powertrain/core/model.py
+++ b/nrel/routee/powertrain/core/model.py
@@ -209,7 +209,7 @@ class Model:
         )
         if feature_set is None:
             raise KeyError(
-                f"Model does not have a feature set with the features: {feature_set.feature_name_list}"
+                f"Model does not have a feature set with the features: {feature_id_to_names(estimator_id)}"
             )
         feature_ranges = {}
         for f in feature_set.features:

--- a/nrel/routee/powertrain/core/model.py
+++ b/nrel/routee/powertrain/core/model.py
@@ -187,7 +187,7 @@ class Model:
 
     def visualize_features(
         self,
-        estimator_id: str,
+        estimator_id: FeatureSetId,
         n_samples: Optional[int] = 100,
         output_path: Optional[str] = None,
         return_predictions: Optional[bool] = False,
@@ -234,7 +234,7 @@ class Model:
 
     def contour(
         self,
-        estimator_id: str,
+        estimator_id: FeatureSetId,
         x_feature: str,
         y_feature: str,
         n_samples: Optional[int] = 100,

--- a/nrel/routee/powertrain/core/model.py
+++ b/nrel/routee/powertrain/core/model.py
@@ -258,7 +258,7 @@ class Model:
         )
         if feature_set is None:
             raise KeyError(
-                f"Model does not have a feature set with the features: {feature_set.feature_name_list}"
+                f"Model does not have a feature set with the features: {feature_id_to_names(estimator_id)}"
             )
         feature_ranges = {}
         for f in feature_set.features:

--- a/nrel/routee/powertrain/validation/feature_visualization.py
+++ b/nrel/routee/powertrain/validation/feature_visualization.py
@@ -174,7 +174,7 @@ def contour_plot(
             each value should be another dictionary containing "lower", "upper", and "n_sample" keys/values.
             These correspond to the lower/upper boundaries and n samples used to generate the plot.
             n_samples must be an integer and lower/upper are floats.
-        output_path: an optional path to save the plots as png files.
+        output_path: an optional path to save the plot as a png file.
     """
     try:
         import matplotlib.pyplot as plt

--- a/nrel/routee/powertrain/validation/feature_visualization.py
+++ b/nrel/routee/powertrain/validation/feature_visualization.py
@@ -1,13 +1,14 @@
 import logging
 import traceback
 from pathlib import Path
-from typing import Dict, Optional, TYPE_CHECKING
+from typing import Dict, Optional, TYPE_CHECKING, Union
 
 import numpy as np
 from pandas import DataFrame
 
 if TYPE_CHECKING:
     from nrel.routee.powertrain.core.model import Model
+    from pandas import Series
 
 log = logging.getLogger(__name__)
 
@@ -15,21 +16,23 @@ log = logging.getLogger(__name__)
 def visualize_features(
     model: "Model",
     feature_ranges: Dict[str, dict],
-    output_path: Optional[str] = None,
-) -> dict:
+    output_path: Optional[Union[str, Path]] = None,
+    return_predictions: Optional[bool] = False,
+) -> Optional[Dict[str, "Series"]]:
     """
     takes a model and generates test links to independently test the model's features
     and creates plots of those predictions
 
-    :param model: the model to be tested
-    :param feature_ranges: a dictionary with value ranges to generate test links
-    :param output_path: if not none, saves results to this location. Else the plots
-        are displayed rather than saved
+    Args:
+        model: the model that will be used to generate the plots
+        feature_ranges: a nested dictionary where each key should be a feature name and
+            each value should be another dictionary containing "lower", "upper", and "n_sample" keys/values.
+            These correspond to the lower/upper boundaries and n samples used to generate the plot.
+            n_samples must be an integer and lower/upper are floats.
+        output_path: an optional path to save the plots as png files.
+        return_predictions: if true, returns the dictionary containing the prediction values
 
-    :return: a dictionary containing the predictions where the key is the feature tested
-
-    :raises Exception due to IOErrors, KeyError due to missing features ranges required
-        by the model
+    Returns: optionally returns a dictionary containing the predictions where the key is the feature tested
     """
     try:
         import matplotlib.pyplot as plt
@@ -84,9 +87,9 @@ def visualize_features(
         sample_points = []
         for feature_name in feature_units_dict.keys():
             points = np.linspace(
-                feature_ranges[feature_name]["min"],
-                feature_ranges[feature_name]["max"],
-                feature_ranges[feature_name]["steps"],
+                feature_ranges[feature_name]["lower"],
+                feature_ranges[feature_name]["upper"],
+                feature_ranges[feature_name]["n_samples"],
             )
             sample_points.append(points)
 
@@ -125,11 +128,11 @@ def visualize_features(
         # if an output filepath is specified, save th results instead of displaying them
         if output_path is not None:
             try:
-                Path(output_path).joinpath(f"{model_name}").mkdir(
-                    parents=True, exist_ok=True
-                )
+                if isinstance(output_path, str):
+                    output_path = Path(output_path)
+                output_path.joinpath(f"{model_name}").mkdir(parents=True, exist_ok=True)
                 plt.savefig(
-                    Path(output_path).joinpath(f"{model_name}/{current_feature}.png"),
+                    output_path.joinpath(f"{model_name}/{current_feature}.png"),
                     format="png",
                 )
             except Exception:
@@ -146,7 +149,8 @@ def visualize_features(
         plt.clf()
         predictions[current_feature] = prediction
 
-    return predictions
+    if return_predictions:
+        return predictions
 
 
 def contour_plot(
@@ -154,23 +158,23 @@ def contour_plot(
     x_feature: str,
     y_feature: str,
     feature_ranges: Dict[str, Dict],
-    output_path: Optional[str] = None,
+    output_path: Optional[Union[str, Path]] = None,
 ):
     """
     takes a model and generates a contour plot of the two test features:
-    x_Feature and y_feature.
+    x_feature and y_feature.
 
-    :param model: the model to be tested
-    :param x_feature: one of the features used to generate the energy matrix
-        and will be the x-axis feature
-    :param y_feature: one of the features used to generate the energy matrix
-        and will be the y-axis feature
-    :param feature_ranges: a dictionary with value ranges to generate test links
-    :param output_path: if not none, saves results to this location.
-        Else the plot is displayed rather than saved
-
-    :raises Exception due to IOErrors, KeyError due to missing features ranges required
-    by the model, KeyError due to incompatible x/y features
+    Args:
+        model: the model that will be used to generate the plots
+        x_feature: one of the features used to generate the energy matrix
+            and will be the x-axis feature
+        y_feature: one of the features used to generate the energy matrix
+            and will be the y-axis feature
+        feature_ranges: a nested dictionary where each key should be a feature name and
+            each value should be another dictionary containing "lower", "upper", and "n_sample" keys/values.
+            These correspond to the lower/upper boundaries and n samples used to generate the plot.
+            n_samples must be an integer and lower/upper are floats.
+        output_path: an optional path to save the plots as png files.
     """
     try:
         import matplotlib.pyplot as plt
@@ -220,9 +224,9 @@ def contour_plot(
 
     points = {
         n: np.linspace(
-            f["min"],
-            f["max"],
-            f["steps"],
+            f["lower"],
+            f["upper"],
+            f["n_samples"],
         )
         for n, f in feature_ranges.items()
     }
@@ -253,9 +257,12 @@ def contour_plot(
     # if an output filepath is specified, save th results instead of displaying them
     if output_path is not None:
         try:
+            if isinstance(output_path, str):
+                output_path = Path(output_path)
+            output_path.joinpath(f"{model_name}").mkdir(parents=True, exist_ok=True)
             plt.savefig(
-                Path(output_path).joinpath(
-                    f"{model_name}_[{x_feature}_{y_feature}].png"
+                output_path.joinpath(
+                    f"{model_name}/{model_name}_[{x_feature}_{y_feature}].png"
                 ),
                 format="png",
             )

--- a/nrel/routee/powertrain/validation/feature_visualization.py
+++ b/nrel/routee/powertrain/validation/feature_visualization.py
@@ -1,18 +1,19 @@
 import logging
 import traceback
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, TYPE_CHECKING
 
 import numpy as np
 from pandas import DataFrame
 
-from nrel.routee.powertrain.core.model import Model
+if TYPE_CHECKING:
+    from nrel.routee.powertrain.core.model import Model
 
 log = logging.getLogger(__name__)
 
 
 def visualize_features(
-    model: Model,
+    model: "Model",
     feature_ranges: Dict[str, dict],
     output_path: Optional[str] = None,
 ) -> dict:
@@ -149,7 +150,7 @@ def visualize_features(
 
 
 def contour_plot(
-    model: Model,
+    model: "Model",
     x_feature: str,
     y_feature: str,
     feature_ranges: Dict[str, Dict],

--- a/nrel/routee/powertrain/validation/feature_visualization.py
+++ b/nrel/routee/powertrain/validation/feature_visualization.py
@@ -151,6 +151,8 @@ def visualize_features(
 
     if return_predictions:
         return predictions
+    else:
+        return None
 
 
 def contour_plot(
@@ -273,3 +275,5 @@ def contour_plot(
         plt.show()
 
     plt.close()
+
+    return None


### PR DESCRIPTION
This PR address issue #5 and adds some QOL methods to the `Model` in the form of `Model.visualize_features` and `Model.contour`. These new methods take an `estimator_id` which corresponds to the estimator keys stored in `Model.estimators` and then uses the constraints of the appropriate estimator to generate the plots. The optional `n_samples` parameter can be passed to increase the number of samples used to generate the plots along with an optional `output_path` parameter for saving plots as png files. 

```python
    def visualize_features(
        self,
        estimator_id: FeatureSetId,
        n_samples: Optional[int] = 100,
        output_path: Optional[str] = None,
        return_predictions: Optional[bool] = False,
    ) -> Optional[Dict[str, "Series"]]:
        """
        generates test links to independently test the model's features
        and creates plots of those predictions for the given estimator id

        Args:
            estimator_id: the estimator id for generating the plots
            n_samples: the number of samples used to generate the plots
            output_path: an optional path to save the plots as png files.
            return_predictions: if true, returns the dictionary containing the prediction values

        Returns: optionally returns a dictionary containing the predictions where the key is the feature tested
        """
          


    def contour(
        self,
        estimator_id: FeatureSetId,
        x_feature: str,
        y_feature: str,
        n_samples: Optional[int] = 100,
        output_path: Optional[str] = None,
    ):
        """
        generates a contour plot of the two test features: x_feature and y_feature.
        for the given estimator id

        Args:
            estimator_id: the estimator id for generating the plots
            x_feature: one of the features used to generate the energy matrix
                and will be the x-axis feature
            y_feature: one of the features used to generate the energy matrix
                and will be the y-axis feature
            n_samples: the number of samples used to generate the plots
            output_path: an optional path to save the plots as png files.
        """
```

Some additional details:
- these wrappers implement the functions found in `nrel.routee.powertrain.validation.feature_visualization`. While we might want to consider rewriting these to be easier to use/more sophisticated, I avoided making any major changes for now. Because of this, I am generating the feature range dictionaries we used previously using the constraints of each feature. My changes should be be consider more as "piping" rather than a visualization overhaul
- since there is no dedicated "estimator_id_to_feature_set" method, this code takes `estimator_id` and breaks it apart into a list of features using `nrel.routee.powertrain.core.features.feature_id_to_names` and then uses the feature list with `Model.metadata.config.get_feature_set` to get the feature set which is ultimately used for accessing the constraints of each feature. Because the estimator id is just a concatenation of the feature names delimited by "&" characters, if we change how these ids are generated in the future it will break this code. Perhaps we should make a "estimator_id_to_feature_set" method eventually, but for now this should work.
- these methods require the user to set the constraints during training. If the constraints are set to -/+inf, the code will return an error and point the user to the visualization functions (where they can pass a custom feature range dict). I didn't look into how constraints are used under the hood, but we might want to make it easier to generate plots with constraints after a model is trained, whether that means making custom data structure for the feature ranges to make them easier to create or allowing the user to add constraints to a model after it is trained. These visualization functions might get overhauled soon, so I opted to not touch anything for now.

Let me know if you would like anything changed or additional functionality added!