### PR TITLE
pin onnxruntime version

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -21,6 +21,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        python -m pip install --upgrade pip
         pip install ".[dev]"
 
     # Build the book

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,7 @@ jobs:
 
       - name: Install package
         run: |
+          pip install pip --upgrade
           pip install ".[dev]"
 
       - name: Run mypy

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     env:
       PYTHON: ${{ matrix.python-version }}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ own drive-cycle data, powertrain modeling system, and road network data to train
 RouteE Powertrain is available on PyPI and can be installed with `pip`:
 
 ```bash
+pip install pip --upgrade
 pip install nrel.routee.powertrain
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nrel.routee.powertrain"
-version = "1.0.4"
+version = "1.1.0"
 description = "RouteE-Powertrain is a tool for predicting energy usage over a set of road links."
 readme = "README.md"
 authors = [{ name = "National Renewable Energy Laboratory" }]
@@ -17,8 +17,8 @@ classifiers = [
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
-dependencies = ["pandas", "numpy", "onnx", "onnxruntime"]
-requires-python = ">=3.8,<3.12"
+dependencies = ["pandas", "numpy", "onnx", "onnxruntime==1.18.1"]
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 scikit = ["scikit-learn", "skl2onnx"]


### PR DESCRIPTION
Pins the onnxruntime version to 1.18.1 to make sure we have the same opsets when training and loading a model.