### PR TITLE
Fix GitHub action for publishing to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
@@ -25,7 +25,7 @@ jobs:
         run: |
           hatch build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: ./dist/*
       - name: Publish package


### PR DESCRIPTION
v1.2.2 build failed because of an outdated version of actions/upload-artifact (@v3, which has been deprecated). I updated actions/checkout and actions/upload-artifact to their most recent versions in publish-pypi.yaml to resolve this.