### PR TITLE
Ndr/additional filter criteria

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,7 @@ Package source lives under `nrel/routee/powertrain/`.
   - `ModelId` — Immutable identifier: `make/model/year/variant/feature_set_id/version` (e.g. `toyota/camry/2016/default/speed_grade/v1`)
   - `ModelInfo` — Lightweight summary returned by `query()` with metadata but no binary data
   - `get_default_registry()` — Factory that selects backend based on `ROUTEE_REGISTRY_BACKEND` env var (`"s3"` or `"local"`, default `"s3"`)
-  - `filter_models()` — Supports exact and fuzzy matching (via `rapidfuzz`) on make, model, year, variant, feature_set_id
-- **`rust/`** (top-level) — PyO3/maturin Rust extension (`powertrain_rust`) providing SmartCore random forest. Build with `cd rust && maturin develop --release`.
+  - `filter_models()` — Supports exact and fuzzy matching (via `rapidfuzz`) on make, model, year, variant, feature_set_id powertrain_type, fuel_type, drivetrain, engine, trim, and accepts additional `custom_filters` **`rust/`** (top-level) — PyO3/maturin Rust extension (`powertrain_rust`) providing SmartCore random forest. Build with `cd rust && maturin develop --release`.
 
 ### Registry
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,33 @@ Package source lives under `nrel/routee/powertrain/`.
 - **`io/`** — `load_model()`, `list_available_models()`, `load_sample_route()`, `to_lookup_table()`
 - **`validation/`** — `ModelErrors`, `compute_errors()`, `visualize_features()`, `contour_plot()`
 - **`resources/`** — Bundled pre-trained models and sample route data
+- **`registry/`** — Pluggable model discovery and retrieval system with multiple backends:
+  - `ModelRegistry` (ABC) — Interface with `query()`, `load()`, `list_models()`, `get_metadata()`
+  - `S3Registry` — Fetches models from a public S3 bucket (`routeecore-bucket`). Uses optional `index.json` for fast queries and hierarchical prefix walking for filtered searches
+  - `LocalRegistry` — Reads models from a local directory tree using glob-based scanning
+  - `ModelId` — Immutable identifier: `make/model/year/variant/feature_set_id/version` (e.g. `toyota/camry/2016/default/speed_grade/v1`)
+  - `ModelInfo` — Lightweight summary returned by `query()` with metadata but no binary data
+  - `get_default_registry()` — Factory that selects backend based on `ROUTEE_REGISTRY_BACKEND` env var (`"s3"` or `"local"`, default `"s3"`)
+  - `filter_models()` — Supports exact and fuzzy matching (via `rapidfuzz`) on make, model, year, variant, feature_set_id
 - **`rust/`** (top-level) — PyO3/maturin Rust extension (`powertrain_rust`) providing SmartCore random forest. Build with `cd rust && maturin develop --release`.
+
+### Registry
+
+The Registry system abstracts model discovery and retrieval, allowing pre-trained models to be served from S3 or the local filesystem with an identical API.
+
+- **Directory/bucket layout**: `<root>/<schema_version>/<make>/<model>/<year>/<variant>/<feature_set_id>/v<N>/` containing `metadata.json` + model binary
+- **Bundled models**: `routee/powertrain/resources/bundled_registry/`
+- **Public entry points** (in `io/load.py`):
+  - `list_available_models(registry=None)` — Returns all `ModelId`s
+  - `query_available_models(...)` — Filtered search returning `ModelInfo` objects
+  - `load_model(name_or_path, registry=None)` — Loads from local path if it exists, otherwise parses as `ModelId` and fetches from registry
+- **Environment variables**:
+  - `ROUTEE_REGISTRY_BACKEND` — `"s3"` (default) or `"local"`
+  - `ROUTEE_SCHEMA_VERSION` — default `"v2"`
+  - `ROUTEE_S3_BUCKET` — default `routeecore-bucket`
+  - `ROUTEE_S3_REGION` — default `us-west-2`
+  - `ROUTEE_S3_ROOT_PREFIX` — default `routee-powertrain-model-library`
+  - `ROUTEE_LOCAL_REGISTRY_ROOT` — local directory root (defaults to bundled registry)
 
 ### Key abstractions
 

--- a/routee/powertrain/__init__.py
+++ b/routee/powertrain/__init__.py
@@ -3,7 +3,9 @@ from pathlib import Path
 
 __all__ = [
     "DataColumn",
+    "Drivetrain",
     "FeatureSet",
+    "FuelType",
     "Constraints",
     "TargetSet",
     "Model",
@@ -20,7 +22,9 @@ __all__ = [
     "contour_plot",
 ]
 
+from .core.drivetrain import Drivetrain
 from .core.features import DataColumn, FeatureSet, Constraints, TargetSet
+from .core.fuel_type import FuelType
 from .core.model import Model
 from .core.model_config import ModelConfig
 from .core.powertrain_type import PowertrainType

--- a/routee/powertrain/core/drivetrain.py
+++ b/routee/powertrain/core/drivetrain.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+
+class Drivetrain(Enum):
+    UNDEFINED = 0
+    FWD = 1
+    RWD = 2
+    AWD = 3
+    FOURWD = 4
+
+    @classmethod
+    def from_string(cls, s: Optional[str]) -> Drivetrain:
+        if not s:
+            return Drivetrain.UNDEFINED
+        e = cls.__members__.get(s.upper())
+        if not e:
+            raise TypeError(
+                f"{s} is not a recognized drivetrain type. "
+                f"Try one of these: {list(Drivetrain.__members__.keys())}"
+            )
+        return e

--- a/routee/powertrain/core/fuel_type.py
+++ b/routee/powertrain/core/fuel_type.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+
+class FuelType(Enum):
+    UNDEFINED = 0
+    GASOLINE = 1
+    DIESEL = 2
+    ELECTRICITY = 3
+    HYDROGEN = 4
+
+    @classmethod
+    def from_string(cls, s: Optional[str]) -> FuelType:
+        if not s:
+            return FuelType.UNDEFINED
+        e = cls.__members__.get(s.upper())
+        if not e:
+            raise TypeError(
+                f"{s} is not a recognized fuel type. "
+                f"Try one of these: {list(FuelType.__members__.keys())}"
+            )
+        return e

--- a/routee/powertrain/core/model_config.py
+++ b/routee/powertrain/core/model_config.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import List
+from typing import List, Optional
 
 from routee.powertrain.core.features import (
     DataColumn,
@@ -53,6 +53,8 @@ class ModelConfig:
     trip_column: str = "trip_id"
 
     apply_real_world_adjustment: bool = True
+
+    mass_lbs: Optional[float] = None
 
     def __post_init__(self):
         # normalize vehicle id fields to lowercase

--- a/routee/powertrain/core/model_config.py
+++ b/routee/powertrain/core/model_config.py
@@ -4,11 +4,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List, Optional
 
+from routee.powertrain.core.drivetrain import Drivetrain
 from routee.powertrain.core.features import (
     DataColumn,
     FeatureSet,
     TargetSet,
 )
+from routee.powertrain.core.fuel_type import FuelType
 from routee.powertrain.core.powertrain_type import PowertrainType
 from routee.powertrain.core.year import Year, parse_year, serialize_year
 
@@ -56,6 +58,11 @@ class ModelConfig:
 
     mass_lbs: Optional[float] = None
 
+    fuel_type: Optional[FuelType] = None
+    drivetrain: Optional[Drivetrain] = None
+    engine: Optional[str] = None
+    trim: Optional[str] = None
+
     def __post_init__(self):
         # normalize vehicle id fields to lowercase
         self.make = self.make.lower()
@@ -83,6 +90,12 @@ class ModelConfig:
 
         if isinstance(self.predict_method, str):
             self.predict_method = PredictMethod.from_string(self.predict_method)
+
+        if isinstance(self.fuel_type, str):
+            self.fuel_type = FuelType.from_string(self.fuel_type)
+
+        if isinstance(self.drivetrain, str):
+            self.drivetrain = Drivetrain.from_string(self.drivetrain)
 
         # now check all the types
         if not isinstance(self.feature_set, FeatureSet):
@@ -121,6 +134,11 @@ class ModelConfig:
         d["target"] = self.target.to_dict()
         d["predict_method"] = self.predict_method.value
         d["year"] = serialize_year(self.year)
+
+        if self.fuel_type is not None:
+            d["fuel_type"] = self.fuel_type.name
+        if self.drivetrain is not None:
+            d["drivetrain"] = self.drivetrain.name
 
         return d
 

--- a/routee/powertrain/io/load.py
+++ b/routee/powertrain/io/load.py
@@ -41,6 +41,7 @@ def query_available_models(
     model: Optional[str] = None,
     year: Optional[int] = None,
     variant: Optional[str] = None,
+    powertrain_type: Optional[str] = None,
     registry: Optional[ModelRegistry] = None,
     fuzzy: bool = True,
     fuzzy_threshold: int = 80,
@@ -56,6 +57,7 @@ def query_available_models(
         model: filter by model name
         year: filter by model year
         variant: filter by variant
+        powertrain_type: filter by powertrain type (e.g. "ICE", "BEV", "HEV")
         registry: a ModelRegistry instance; defaults to get_default_registry()
         fuzzy: if True, use fuzzy string matching for string fields (default True)
         fuzzy_threshold: minimum score (0–100) for a fuzzy match (default 80)
@@ -72,6 +74,7 @@ def query_available_models(
         model=model,
         year=year,
         variant=variant,
+        powertrain_type=powertrain_type,
         fuzzy=fuzzy,
         fuzzy_threshold=fuzzy_threshold,
     )

--- a/routee/powertrain/io/load.py
+++ b/routee/powertrain/io/load.py
@@ -42,6 +42,10 @@ def query_available_models(
     year: Optional[int] = None,
     variant: Optional[str] = None,
     powertrain_type: Optional[str] = None,
+    fuel_type: Optional[str] = None,
+    drivetrain: Optional[str] = None,
+    engine: Optional[str] = None,
+    trim: Optional[str] = None,
     custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
     registry: Optional[ModelRegistry] = None,
     fuzzy: bool = True,
@@ -59,6 +63,10 @@ def query_available_models(
         year: filter by model year
         variant: filter by variant
         powertrain_type: filter by powertrain type (e.g. "ICE", "BEV", "HEV")
+        fuel_type: filter by fuel type (e.g. "GASOLINE", "DIESEL", "ELECTRICITY")
+        drivetrain: filter by drivetrain (e.g. "FWD", "RWD", "AWD")
+        engine: filter by engine specification (e.g. "4cyl", "2.0tdi")
+        trim: filter by trim level (e.g. "sport", "active")
         custom_filters: optional list of callables that accept a ModelInfo
             and return True to keep the model or False to exclude it.
             For example: ``[lambda m: m.mass_lbs is not None and m.mass_lbs > 10000]``
@@ -79,6 +87,10 @@ def query_available_models(
         year=year,
         variant=variant,
         powertrain_type=powertrain_type,
+        fuel_type=fuel_type,
+        drivetrain=drivetrain,
+        engine=engine,
+        trim=trim,
         custom_filters=custom_filters,
         fuzzy=fuzzy,
         fuzzy_threshold=fuzzy_threshold,

--- a/routee/powertrain/io/load.py
+++ b/routee/powertrain/io/load.py
@@ -1,6 +1,6 @@
 import logging
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Sequence, Union
 
 import pandas as pd
 
@@ -42,6 +42,7 @@ def query_available_models(
     year: Optional[int] = None,
     variant: Optional[str] = None,
     powertrain_type: Optional[str] = None,
+    custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
     registry: Optional[ModelRegistry] = None,
     fuzzy: bool = True,
     fuzzy_threshold: int = 80,
@@ -58,6 +59,9 @@ def query_available_models(
         year: filter by model year
         variant: filter by variant
         powertrain_type: filter by powertrain type (e.g. "ICE", "BEV", "HEV")
+        custom_filters: optional list of callables that accept a ModelInfo
+            and return True to keep the model or False to exclude it.
+            For example: ``[lambda m: m.mass_lbs is not None and m.mass_lbs > 10000]``
         registry: a ModelRegistry instance; defaults to get_default_registry()
         fuzzy: if True, use fuzzy string matching for string fields (default True)
         fuzzy_threshold: minimum score (0–100) for a fuzzy match (default 80)
@@ -75,6 +79,7 @@ def query_available_models(
         year=year,
         variant=variant,
         powertrain_type=powertrain_type,
+        custom_filters=custom_filters,
         fuzzy=fuzzy,
         fuzzy_threshold=fuzzy_threshold,
     )

--- a/routee/powertrain/registry/filtering.py
+++ b/routee/powertrain/registry/filtering.py
@@ -23,6 +23,7 @@ def filter_models(
     year: Optional[int] = None,
     variant: Optional[str] = None,
     feature_set_id: Optional[str] = None,
+    powertrain_type: Optional[str] = None,
     fuzzy: bool = True,
     fuzzy_threshold: int = 80,
 ) -> List[ModelInfo]:
@@ -57,6 +58,14 @@ def filter_models(
             for m in results
             if _matches(
                 feature_set_id, m.model_id.feature_set_id, fuzzy, fuzzy_threshold
+            )
+        ]
+    if powertrain_type is not None:
+        results = [
+            m
+            for m in results
+            if _matches(
+                powertrain_type, m.powertrain_type.lower(), fuzzy, fuzzy_threshold
             )
         ]
     return results

--- a/routee/powertrain/registry/filtering.py
+++ b/routee/powertrain/registry/filtering.py
@@ -24,6 +24,10 @@ def filter_models(
     variant: Optional[str] = None,
     feature_set_id: Optional[str] = None,
     powertrain_type: Optional[str] = None,
+    fuel_type: Optional[str] = None,
+    drivetrain: Optional[str] = None,
+    engine: Optional[str] = None,
+    trim: Optional[str] = None,
     custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
     fuzzy: bool = True,
     fuzzy_threshold: int = 80,
@@ -68,6 +72,34 @@ def filter_models(
             if _matches(
                 powertrain_type, m.powertrain_type.lower(), fuzzy, fuzzy_threshold
             )
+        ]
+    if fuel_type is not None:
+        results = [
+            m
+            for m in results
+            if m.fuel_type is not None
+            and _matches(fuel_type, m.fuel_type.lower(), fuzzy, fuzzy_threshold)
+        ]
+    if drivetrain is not None:
+        results = [
+            m
+            for m in results
+            if m.drivetrain is not None
+            and _matches(drivetrain, m.drivetrain.lower(), fuzzy, fuzzy_threshold)
+        ]
+    if engine is not None:
+        results = [
+            m
+            for m in results
+            if m.engine is not None
+            and _matches(engine, m.engine.lower(), fuzzy, fuzzy_threshold)
+        ]
+    if trim is not None:
+        results = [
+            m
+            for m in results
+            if m.trim is not None
+            and _matches(trim, m.trim.lower(), fuzzy, fuzzy_threshold)
         ]
     if custom_filters is not None:
         for fn in custom_filters:

--- a/routee/powertrain/registry/filtering.py
+++ b/routee/powertrain/registry/filtering.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Callable, List, Optional, Sequence
 
 from rapidfuzz import fuzz
 
@@ -24,6 +24,7 @@ def filter_models(
     variant: Optional[str] = None,
     feature_set_id: Optional[str] = None,
     powertrain_type: Optional[str] = None,
+    custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
     fuzzy: bool = True,
     fuzzy_threshold: int = 80,
 ) -> List[ModelInfo]:
@@ -68,4 +69,7 @@ def filter_models(
                 powertrain_type, m.powertrain_type.lower(), fuzzy, fuzzy_threshold
             )
         ]
+    if custom_filters is not None:
+        for fn in custom_filters:
+            results = [m for m in results if fn(m)]
     return results

--- a/routee/powertrain/registry/local.py
+++ b/routee/powertrain/registry/local.py
@@ -72,6 +72,10 @@ def _model_info_from_metadata(
         vehicle_description=config["vehicle_description"],
         path=path,
         mass_lbs=config.get("mass_lbs"),
+        fuel_type=config.get("fuel_type"),
+        drivetrain=config.get("drivetrain"),
+        engine=config.get("engine"),
+        trim=config.get("trim"),
     )
 
 
@@ -148,6 +152,10 @@ class LocalRegistry(ModelRegistry):
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
         powertrain_type: Optional[str] = None,
+        fuel_type: Optional[str] = None,
+        drivetrain: Optional[str] = None,
+        engine: Optional[str] = None,
+        trim: Optional[str] = None,
         custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
@@ -161,6 +169,10 @@ class LocalRegistry(ModelRegistry):
             variant=variant,
             feature_set_id=feature_set_id,
             powertrain_type=powertrain_type,
+            fuel_type=fuel_type,
+            drivetrain=drivetrain,
+            engine=engine,
+            trim=trim,
             custom_filters=custom_filters,
             fuzzy=fuzzy,
             fuzzy_threshold=fuzzy_threshold,

--- a/routee/powertrain/registry/local.py
+++ b/routee/powertrain/registry/local.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Sequence, Union
 
 from routee.powertrain.core.model import Model
 from routee.powertrain.core.year import parse_year
@@ -71,6 +71,7 @@ def _model_info_from_metadata(
         powertrain_type=config["powertrain_type"],
         vehicle_description=config["vehicle_description"],
         path=path,
+        mass_lbs=config.get("mass_lbs"),
     )
 
 
@@ -147,6 +148,7 @@ class LocalRegistry(ModelRegistry):
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
         powertrain_type: Optional[str] = None,
+        custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
@@ -159,6 +161,7 @@ class LocalRegistry(ModelRegistry):
             variant=variant,
             feature_set_id=feature_set_id,
             powertrain_type=powertrain_type,
+            custom_filters=custom_filters,
             fuzzy=fuzzy,
             fuzzy_threshold=fuzzy_threshold,
         )

--- a/routee/powertrain/registry/local.py
+++ b/routee/powertrain/registry/local.py
@@ -146,6 +146,7 @@ class LocalRegistry(ModelRegistry):
         year: Optional[int] = None,
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
+        powertrain_type: Optional[str] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
@@ -157,6 +158,7 @@ class LocalRegistry(ModelRegistry):
             year=year,
             variant=variant,
             feature_set_id=feature_set_id,
+            powertrain_type=powertrain_type,
             fuzzy=fuzzy,
             fuzzy_threshold=fuzzy_threshold,
         )

--- a/routee/powertrain/registry/model_id.py
+++ b/routee/powertrain/registry/model_id.py
@@ -115,6 +115,10 @@ class ModelInfo:
     vehicle_description: str
     path: Optional[str] = None
     mass_lbs: Optional[float] = None
+    fuel_type: Optional[str] = None
+    drivetrain: Optional[str] = None
+    engine: Optional[str] = None
+    trim: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -126,6 +130,10 @@ class ModelInfo:
             "vehicle_description": self.vehicle_description,
             "path": self.path,
             "mass_lbs": self.mass_lbs,
+            "fuel_type": self.fuel_type,
+            "drivetrain": self.drivetrain,
+            "engine": self.engine,
+            "trim": self.trim,
         }
 
     @classmethod
@@ -133,6 +141,10 @@ class ModelInfo:
         d = d.copy()
         d["model_id"] = ModelId.from_dict(d["model_id"])
         d.setdefault("mass_lbs", None)
+        d.setdefault("fuel_type", None)
+        d.setdefault("drivetrain", None)
+        d.setdefault("engine", None)
+        d.setdefault("trim", None)
         return cls(**d)
 
     def __repr__(self) -> str:
@@ -149,5 +161,9 @@ class ModelInfo:
             f"  features:       {self.feature_names}",
             f"  targets:        {self.target_names}",
             f"  mass_lbs:       {self.mass_lbs}",
+            f"  fuel_type:      {self.fuel_type}",
+            f"  drivetrain:     {self.drivetrain}",
+            f"  engine:         {self.engine}",
+            f"  trim:           {self.trim}",
         ]
         return "\n".join(lines)

--- a/routee/powertrain/registry/model_id.py
+++ b/routee/powertrain/registry/model_id.py
@@ -114,6 +114,7 @@ class ModelInfo:
     powertrain_type: str
     vehicle_description: str
     path: Optional[str] = None
+    mass_lbs: Optional[float] = None
 
     def to_dict(self) -> dict:
         return {
@@ -124,12 +125,14 @@ class ModelInfo:
             "powertrain_type": self.powertrain_type,
             "vehicle_description": self.vehicle_description,
             "path": self.path,
+            "mass_lbs": self.mass_lbs,
         }
 
     @classmethod
     def from_dict(cls, d: dict) -> ModelInfo:
         d = d.copy()
         d["model_id"] = ModelId.from_dict(d["model_id"])
+        d.setdefault("mass_lbs", None)
         return cls(**d)
 
     def __repr__(self) -> str:
@@ -145,5 +148,6 @@ class ModelInfo:
             f"  estimator:      {self.estimator_type}",
             f"  features:       {self.feature_names}",
             f"  targets:        {self.target_names}",
+            f"  mass_lbs:       {self.mass_lbs}",
         ]
         return "\n".join(lines)

--- a/routee/powertrain/registry/registry.py
+++ b/routee/powertrain/registry/registry.py
@@ -32,6 +32,10 @@ class ModelRegistry(ABC):
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
         powertrain_type: Optional[str] = None,
+        fuel_type: Optional[str] = None,
+        drivetrain: Optional[str] = None,
+        engine: Optional[str] = None,
+        trim: Optional[str] = None,
         custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
@@ -49,6 +53,10 @@ class ModelRegistry(ABC):
             variant: filter by variant
             feature_set_id: filter by feature set id
             powertrain_type: filter by powertrain type (e.g. "ICE", "BEV", "HEV")
+            fuel_type: filter by fuel type (e.g. "GASOLINE", "DIESEL", "ELECTRICITY")
+            drivetrain: filter by drivetrain (e.g. "FWD", "RWD", "AWD")
+            engine: filter by engine specification (e.g. "4cyl", "2.0tdi")
+            trim: filter by trim level (e.g. "sport", "active")
             custom_filters: optional list of callables that accept a ModelInfo
                 and return True to keep the model or False to exclude it
             fuzzy: if True, use fuzzy string matching for string

--- a/routee/powertrain/registry/registry.py
+++ b/routee/powertrain/registry/registry.py
@@ -31,6 +31,7 @@ class ModelRegistry(ABC):
         year: Optional[int] = None,
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
+        powertrain_type: Optional[str] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
@@ -46,6 +47,7 @@ class ModelRegistry(ABC):
             year: filter by model year
             variant: filter by variant
             feature_set_id: filter by feature set id
+            powertrain_type: filter by powertrain type (e.g. "ICE", "BEV", "HEV")
             fuzzy: if True, use fuzzy string matching for string
                 fields (default True)
             fuzzy_threshold: minimum score (0–100) for a fuzzy match

--- a/routee/powertrain/registry/registry.py
+++ b/routee/powertrain/registry/registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Sequence, Union
 
 from routee.powertrain.core.model import Model
 from routee.powertrain.registry.model_id import ModelId, ModelInfo
@@ -32,6 +32,7 @@ class ModelRegistry(ABC):
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
         powertrain_type: Optional[str] = None,
+        custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
@@ -48,6 +49,8 @@ class ModelRegistry(ABC):
             variant: filter by variant
             feature_set_id: filter by feature set id
             powertrain_type: filter by powertrain type (e.g. "ICE", "BEV", "HEV")
+            custom_filters: optional list of callables that accept a ModelInfo
+                and return True to keep the model or False to exclude it
             fuzzy: if True, use fuzzy string matching for string
                 fields (default True)
             fuzzy_threshold: minimum score (0–100) for a fuzzy match

--- a/routee/powertrain/registry/s3.py
+++ b/routee/powertrain/registry/s3.py
@@ -288,6 +288,7 @@ class S3Registry(ModelRegistry):
         year: Optional[int] = None,
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
+        powertrain_type: Optional[str] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
@@ -300,12 +301,14 @@ class S3Registry(ModelRegistry):
                 year=year,
                 variant=variant,
                 feature_set_id=feature_set_id,
+                powertrain_type=powertrain_type,
                 fuzzy=fuzzy,
                 fuzzy_threshold=fuzzy_threshold,
             )
 
         has_filters = any(
-            v is not None for v in (make, model, year, variant, feature_set_id)
+            v is not None
+            for v in (make, model, year, variant, feature_set_id, powertrain_type)
         )
         if not has_filters:
             return self._scan_models()
@@ -348,6 +351,13 @@ class S3Registry(ModelRegistry):
                 metadata_dict = json.loads(data)
                 dir_key = prefix.rstrip("/")
                 info = _model_info_from_metadata(metadata_dict, model_id, dir_key)
+                if powertrain_type is not None and not _matches(
+                    powertrain_type,
+                    info.powertrain_type.lower(),
+                    fuzzy,
+                    fuzzy_threshold,
+                ):
+                    continue
                 results.append(info)
             except Exception:
                 continue

--- a/routee/powertrain/registry/s3.py
+++ b/routee/powertrain/registry/s3.py
@@ -89,6 +89,10 @@ def _model_info_from_metadata(
         vehicle_description=config["vehicle_description"],
         path=path,
         mass_lbs=config.get("mass_lbs"),
+        fuel_type=config.get("fuel_type"),
+        drivetrain=config.get("drivetrain"),
+        engine=config.get("engine"),
+        trim=config.get("trim"),
     )
 
 
@@ -290,6 +294,10 @@ class S3Registry(ModelRegistry):
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
         powertrain_type: Optional[str] = None,
+        fuel_type: Optional[str] = None,
+        drivetrain: Optional[str] = None,
+        engine: Optional[str] = None,
+        trim: Optional[str] = None,
         custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
@@ -304,6 +312,10 @@ class S3Registry(ModelRegistry):
                 variant=variant,
                 feature_set_id=feature_set_id,
                 powertrain_type=powertrain_type,
+                fuel_type=fuel_type,
+                drivetrain=drivetrain,
+                engine=engine,
+                trim=trim,
                 custom_filters=custom_filters,
                 fuzzy=fuzzy,
                 fuzzy_threshold=fuzzy_threshold,
@@ -311,7 +323,18 @@ class S3Registry(ModelRegistry):
 
         has_filters = any(
             v is not None
-            for v in (make, model, year, variant, feature_set_id, powertrain_type)
+            for v in (
+                make,
+                model,
+                year,
+                variant,
+                feature_set_id,
+                powertrain_type,
+                fuel_type,
+                drivetrain,
+                engine,
+                trim,
+            )
         )
         has_custom_filters = custom_filters is not None and len(custom_filters) > 0
         if not has_filters and not has_custom_filters:
@@ -355,11 +378,40 @@ class S3Registry(ModelRegistry):
                 metadata_dict = json.loads(data)
                 dir_key = prefix.rstrip("/")
                 info = _model_info_from_metadata(metadata_dict, model_id, dir_key)
+                # Apply metadata-level filters that can't be narrowed
+                # via the S3 directory hierarchy.
                 if powertrain_type is not None and not _matches(
                     powertrain_type,
                     info.powertrain_type.lower(),
                     fuzzy,
                     fuzzy_threshold,
+                ):
+                    continue
+                if fuel_type is not None and (
+                    info.fuel_type is None
+                    or not _matches(
+                        fuel_type, info.fuel_type.lower(), fuzzy, fuzzy_threshold
+                    )
+                ):
+                    continue
+                if drivetrain is not None and (
+                    info.drivetrain is None
+                    or not _matches(
+                        drivetrain,
+                        info.drivetrain.lower(),
+                        fuzzy,
+                        fuzzy_threshold,
+                    )
+                ):
+                    continue
+                if engine is not None and (
+                    info.engine is None
+                    or not _matches(engine, info.engine.lower(), fuzzy, fuzzy_threshold)
+                ):
+                    continue
+                if trim is not None and (
+                    info.trim is None
+                    or not _matches(trim, info.trim.lower(), fuzzy, fuzzy_threshold)
                 ):
                     continue
                 if custom_filters and not all(fn(info) for fn in custom_filters):

--- a/routee/powertrain/registry/s3.py
+++ b/routee/powertrain/registry/s3.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, Sequence, Union
 
 from routee.powertrain.core.metadata import SCHEMA_VERSION_STRING
 from routee.powertrain.core.model import Model
@@ -88,6 +88,7 @@ def _model_info_from_metadata(
         powertrain_type=config["powertrain_type"],
         vehicle_description=config["vehicle_description"],
         path=path,
+        mass_lbs=config.get("mass_lbs"),
     )
 
 
@@ -289,6 +290,7 @@ class S3Registry(ModelRegistry):
         variant: Optional[str] = None,
         feature_set_id: Optional[str] = None,
         powertrain_type: Optional[str] = None,
+        custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
@@ -302,6 +304,7 @@ class S3Registry(ModelRegistry):
                 variant=variant,
                 feature_set_id=feature_set_id,
                 powertrain_type=powertrain_type,
+                custom_filters=custom_filters,
                 fuzzy=fuzzy,
                 fuzzy_threshold=fuzzy_threshold,
             )
@@ -310,7 +313,8 @@ class S3Registry(ModelRegistry):
             v is not None
             for v in (make, model, year, variant, feature_set_id, powertrain_type)
         )
-        if not has_filters:
+        has_custom_filters = custom_filters is not None and len(custom_filters) > 0
+        if not has_filters and not has_custom_filters:
             return self._scan_models()
 
         # Walk the S3 hierarchy level-by-level, narrowing at each step.
@@ -357,6 +361,8 @@ class S3Registry(ModelRegistry):
                     fuzzy,
                     fuzzy_threshold,
                 ):
+                    continue
+                if custom_filters and not all(fn(info) for fn in custom_filters):
                     continue
                 results.append(info)
             except Exception:

--- a/scripts/convert_legacy_models.py
+++ b/scripts/convert_legacy_models.py
@@ -18,8 +18,8 @@ Usage
     python scripts/convert_legacy_models.py path/to/model.json output_dir/ \\
         --make toyota --model camry --year 2016 --trim 4cyl_2wd
 
-See also ``scripts/convert_nrel_library.py`` for batch-converting the bundled
-NREL model library.
+See also ``scripts/convert_nlr_library.py`` for batch-converting the bundled
+NLR model library.
 """
 
 from __future__ import annotations
@@ -48,6 +48,10 @@ class VehicleIdentity:
     model: str
     year: int | str
     variant: str = "default"
+    fuel_type: Optional[str] = None
+    drivetrain: Optional[str] = None
+    engine: Optional[str] = None
+    trim: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +113,41 @@ def _find_feature_set_for_id(
         if fs_id == feature_set_id:
             return fs
     return None
+
+
+_DIESEL_NAME_PATTERNS = {"diesel", "tdi", "dci", "328d", "vdi"}
+
+
+def _infer_fuel_type(
+    model_name: str, powertrain_type: str, target_names: List[str]
+) -> Optional[str]:
+    """Infer fuel type from powertrain type, model name, and target metrics."""
+    pt = powertrain_type.upper()
+    name = model_name.lower()
+    targets = " ".join(t.lower() for t in target_names)
+
+    if pt == "BEV":
+        return "ELECTRICITY"
+    if pt == "PHEV_EV_MODE":
+        return "ELECTRICITY"
+    if pt == "PHEV_HEV_MODE":
+        return "GASOLINE"
+
+    # Hydrogen fuel cell
+    if "kg_h2" in targets or "fuel_cell" in name or name == "mirai":
+        return "HYDROGEN"
+
+    # Diesel detection from target metric or model name keywords
+    if "gde" in targets:
+        return "DIESEL"
+    for pattern in _DIESEL_NAME_PATTERNS:
+        if pattern in name:
+            return "DIESEL"
+
+    if pt == "HEAVY_DUTY":
+        return "DIESEL"
+
+    return "GASOLINE"
 
 
 def convert_legacy_json(
@@ -200,12 +239,16 @@ def convert_legacy_json(
             }
 
         # Build new config
+        powertrain_type = old_config.get("powertrain_type", "UNDEFINED")
+        target_dict = old_config["target"]
+        target_names = [t["name"] for t in target_dict.get("targets", [])]
+
         new_config = {
             "vehicle_description": old_config.get("vehicle_description", ""),
-            "powertrain_type": old_config.get("powertrain_type", "UNDEFINED"),
+            "powertrain_type": powertrain_type,
             "feature_set": feature_set_dict,
             "distance": old_config["distance"],
-            "target": old_config["target"],
+            "target": target_dict,
             "make": identity.make,
             "model": identity.model,
             "year": identity.year,
@@ -217,6 +260,19 @@ def convert_legacy_json(
                 "apply_real_world_adjustment", True
             ),
         }
+
+        # Add vehicle attribute fields
+        fuel_type = identity.fuel_type
+        if fuel_type is None:
+            fuel_type = _infer_fuel_type(identity.model, powertrain_type, target_names)
+        if fuel_type is not None:
+            new_config["fuel_type"] = fuel_type
+        if identity.drivetrain is not None:
+            new_config["drivetrain"] = identity.drivetrain
+        if identity.engine is not None:
+            new_config["engine"] = identity.engine
+        if identity.trim is not None:
+            new_config["trim"] = identity.trim
 
         # Build errors for this estimator
         estimator_errors_dict = old_errors.get(fs_id)
@@ -301,6 +357,23 @@ def main():
         "--variant", default="default", help="Model variant (e.g. charge_depleting)."
     )
     parser.add_argument("--version", type=int, default=1, help="Model version number.")
+    parser.add_argument(
+        "--fuel-type",
+        default=None,
+        help="Fuel type (e.g. GASOLINE, DIESEL, ELECTRICITY, HYDROGEN). "
+        "Auto-inferred from powertrain type and model name if not provided.",
+    )
+    parser.add_argument(
+        "--drivetrain",
+        default=None,
+        help="Drivetrain (e.g. FWD, RWD, AWD, FOURWD).",
+    )
+    parser.add_argument(
+        "--engine", default=None, help="Engine spec (e.g. 4cyl, 2.0tdi, 300kw)."
+    )
+    parser.add_argument(
+        "--trim", default=None, help="Trim level (e.g. sport, le, active)."
+    )
 
     args = parser.parse_args()
 
@@ -309,6 +382,10 @@ def main():
         model=args.model,
         year=args.year,
         variant=args.variant,
+        fuel_type=args.fuel_type,
+        drivetrain=args.drivetrain,
+        engine=args.engine,
+        trim=args.trim,
     )
     created = convert_legacy_json(
         json_path=args.json_path,

--- a/scripts/convert_nlr_library.py
+++ b/scripts/convert_nlr_library.py
@@ -20,11 +20,145 @@ import argparse
 import logging
 import re
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from convert_legacy_models import VehicleIdentity, convert_legacy_json
 
 log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Vehicle attribute extraction
+# ---------------------------------------------------------------------------
+
+# Maps (make, base_model) → drivetrain for models that use "2wd" in their name.
+# 2WD is ambiguous (could be FWD or RWD), so we resolve per vehicle.
+_2WD_DRIVETRAIN_MAP: Dict[tuple, str] = {
+    ("audi", "a3"): "FWD",
+    ("bmw", "328d"): "RWD",
+    ("chevrolet", "colorado"): "RWD",
+    ("chevrolet", "malibu"): "FWD",
+    ("ford", "escape"): "FWD",
+    ("ford", "explorer"): "RWD",
+    ("hyundai", "elantra"): "FWD",
+    ("maruti", "swift"): "FWD",
+    ("tesla", "model_s60"): "RWD",
+    ("toyota", "camry"): "FWD",
+    ("toyota", "corolla"): "FWD",
+}
+
+# Engine spec patterns to search for in model names (order matters: longest first)
+_ENGINE_PATTERNS = [
+    re.compile(r"(\d+\.\d+_dci)"),  # 1.5_dci
+    re.compile(r"(\d+\.\d+_mpi)"),  # 1.0_mpi
+    re.compile(r"(\d+\.\d+tsi)"),  # 1.5tsi
+    re.compile(r"(\d+\.\d+tdi)"),  # 2.0tdi
+    re.compile(r"(\d+\.\d+_l)"),  # 3.5_l
+    # Note: kwh values (24_kwh, 30_kwh) are treated as trim, not engine
+    re.compile(r"(\d+kw)\b"),  # 300kw, 400kw
+    re.compile(r"(\d+cyl)"),  # 4cyl
+]
+
+# Known trim values that appear as suffixes in model names
+_KNOWN_TRIMS = {
+    "active",
+    "sport",
+    "le",
+    "mid",
+    "g",
+    "vdi",
+    "i-stop",
+    "authentique",
+    "e_j_mt",
+    "hardtop_2_door",
+    "double_cab",
+    "daycab",
+    "sleeper",
+    "24_kwh",
+    "30_kwh",
+}
+
+
+def _extract_drivetrain(make: str, model: str) -> Optional[str]:
+    """Extract drivetrain from the model name.
+
+    Returns a Drivetrain enum name string or None.
+    """
+    name = model.lower()
+
+    # Explicit drivetrain patterns
+    if "_rwd" in name or name.endswith("_rwd"):
+        return "RWD"
+    if "_fwd" in name or name.endswith("_fwd"):
+        return "FWD"
+    if "_4wd" in name or name.endswith("_4wd"):
+        return "FOURWD"
+    if "xdrive" in name:
+        return "AWD"
+    if "dual_motor" in name:
+        return "AWD"
+    if name.endswith("_twin"):
+        return "AWD"
+
+    # 2WD: resolve per vehicle using lookup table
+    if "_2wd" in name or name.endswith("_2wd"):
+        # Find the base model by stripping everything after common suffixes
+        for (m, base), dt in _2WD_DRIVETRAIN_MAP.items():
+            if make.lower() == m and base in name:
+                return dt
+        log.warning(
+            "Could not resolve 2wd drivetrain for %s/%s; leaving as None",
+            make,
+            model,
+        )
+        return None
+
+    return None
+
+
+def _extract_engine(model: str) -> Optional[str]:
+    """Extract engine/motor specification from the model name."""
+    name = model.lower()
+    for pattern in _ENGINE_PATTERNS:
+        m = pattern.search(name)
+        if m:
+            return m.group(1)
+
+    # Special case: vios_1.5_g → engine is "1.5", trim is "g"
+    if "vios" in name:
+        m = re.search(r"(\d+\.\d+)", name)
+        if m:
+            return m.group(1)
+
+    return None
+
+
+def _extract_trim(make: str, model: str) -> Optional[str]:
+    """Extract trim level from the model name using known trim values."""
+    name = model.lower()
+
+    # Heavy duty: cab type is trim
+    if make.lower() == "generic_heavy_duty":
+        if "daycab" in name:
+            return "daycab"
+        if "sleeper" in name:
+            return "sleeper"
+
+    # Check for known trim values anywhere in the model name as a
+    # delimited segment (not just at the end, since drivetrain suffixes
+    # like _4wd may follow the trim, e.g. "hilux_double_cab_4wd").
+    # Try multi-word trims first (longest match).
+    for trim in sorted(_KNOWN_TRIMS, key=len, reverse=True):
+        # Match as _trim_ in middle, or _trim at end
+        needle = f"_{trim}"
+        pos = name.find(needle)
+        if pos != -1:
+            after = pos + len(needle)
+            # Ensure it's a full segment (followed by _ or end of string)
+            if after == len(name) or name[after] == "_":
+                return trim
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -317,6 +451,31 @@ def _resolve_year(identity: VehicleIdentity, original_stem: str) -> VehicleIdent
 
 
 # ---------------------------------------------------------------------------
+# Enrich identity with vehicle attributes
+# ---------------------------------------------------------------------------
+
+
+def _enrich_vehicle_attributes(identity: VehicleIdentity) -> VehicleIdentity:
+    """Populate fuel_type, drivetrain, engine, and trim on the identity.
+
+    fuel_type is left as None here — it is auto-inferred inside
+    ``convert_legacy_json`` from the powertrain_type and target metrics
+    in the actual model JSON (which has more information than the filename).
+    """
+    return VehicleIdentity(
+        make=identity.make,
+        model=identity.model,
+        year=identity.year,
+        variant=identity.variant,
+        # fuel_type is inferred later in convert_legacy_json
+        fuel_type=None,
+        drivetrain=_extract_drivetrain(identity.make, identity.model),
+        engine=_extract_engine(identity.model),
+        trim=_extract_trim(identity.make, identity.model),
+    )
+
+
+# ---------------------------------------------------------------------------
 # Batch conversion
 # ---------------------------------------------------------------------------
 
@@ -342,6 +501,7 @@ def convert_library(
         try:
             identity = _parse_library_filename(json_path.name)
             identity = _resolve_year(identity, json_path.name)
+            identity = _enrich_vehicle_attributes(identity)
 
             created = convert_legacy_json(
                 json_path=json_path,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -205,3 +205,164 @@ class TestLocalRegistry(TestCase):
 
         results = self.registry.query(make="toyota", powertrain_type="BEV")
         self.assertEqual(len(results), 0)
+
+    def test_mass_lbs_in_model_info(self):
+        """ModelInfo should include mass_lbs from the config."""
+        results = self.registry.query(make="toyota")
+        info = results[0]
+        # The test model config doesn't set mass_lbs, so it should be None
+        self.assertIsNone(info.mass_lbs)
+
+    def test_custom_filter_single(self):
+        """A single custom filter function should be applied."""
+        # Filter that accepts everything
+        results = self.registry.query(custom_filters=[lambda m: True])
+        self.assertEqual(len(results), 1)
+
+        # Filter that rejects everything
+        results = self.registry.query(custom_filters=[lambda m: False])
+        self.assertEqual(len(results), 0)
+
+    def test_custom_filter_on_feature_names(self):
+        """Custom filter can inspect ModelInfo fields like feature_names."""
+        results = self.registry.query(
+            custom_filters=[lambda m: "speed_mph" in m.feature_names]
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self.registry.query(
+            custom_filters=[lambda m: "nonexistent_feature" in m.feature_names]
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_custom_filter_multiple(self):
+        """Multiple custom filters are all applied (AND logic)."""
+        results = self.registry.query(
+            custom_filters=[
+                lambda m: m.powertrain_type == "ICE",
+                lambda m: "speed_mph" in m.feature_names,
+            ]
+        )
+        self.assertEqual(len(results), 1)
+
+        # Second filter rejects
+        results = self.registry.query(
+            custom_filters=[
+                lambda m: m.powertrain_type == "ICE",
+                lambda m: False,
+            ]
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_custom_filter_combined_with_named_filters(self):
+        """Custom filters work alongside named filters like make."""
+        results = self.registry.query(
+            make="toyota",
+            custom_filters=[lambda m: m.powertrain_type == "ICE"],
+        )
+        self.assertEqual(len(results), 1)
+
+        results = self.registry.query(
+            make="ford",
+            custom_filters=[lambda m: m.powertrain_type == "ICE"],
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_custom_filter_on_mass_lbs(self):
+        """Custom filter can filter by mass_lbs (None-safe)."""
+        # Our test model has no mass_lbs, so filtering for heavy vehicles returns nothing
+        results = self.registry.query(
+            custom_filters=[lambda m: m.mass_lbs is not None and m.mass_lbs > 10000]
+        )
+        self.assertEqual(len(results), 0)
+
+        # Filtering for None mass should return our model
+        results = self.registry.query(custom_filters=[lambda m: m.mass_lbs is None])
+        self.assertEqual(len(results), 1)
+
+
+class TestMassLbsModelConfig(TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+        self.schema_version = "v2"
+
+        data_path = (
+            this_dir
+            / Path("routee-powertrain-test-data")
+            / Path("sample_train_data.csv")
+        )
+        df = pd.read_csv(data_path)
+        config = pt.ModelConfig(
+            vehicle_description="Heavy Duty Truck",
+            powertrain_type=pt.PowertrainType.HEAVY_DUTY,
+            feature_set=pt.FeatureSet(
+                features=[
+                    pt.DataColumn(name="speed_mph", units="mph"),
+                    pt.DataColumn(name="grade_dec", units="decimal"),
+                ],
+            ),
+            distance=pt.DataColumn(name="miles", units="miles"),
+            target=pt.TargetSet(
+                targets=[
+                    pt.DataColumn(
+                        name="gallons_fastsim",
+                        units="gallons_gasoline",
+                        constraints=pt.Constraints(lower=0.0, upper=100.0),
+                    )
+                ],
+            ),
+            make="Freightliner",
+            model="Cascadia",
+            year=2022,
+            mass_lbs=33000.0,
+        )
+        trainer = SklearnRandomForestTrainer()
+        model = trainer.train(df, config)
+
+        model_id = ModelId(
+            "freightliner", "cascadia", 2022, "default", "grade_dec_speed_mph", 1
+        )
+        rel_path = f"{self.schema_version}/{model_id.to_path()}"
+        full_path = self.root / rel_path
+        save_model_directory(model, full_path)
+
+        self.registry = LocalRegistry(
+            root=self.root, schema_version=self.schema_version
+        )
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp)
+
+    def test_mass_lbs_populated(self):
+        """ModelInfo should have mass_lbs when set in ModelConfig."""
+        results = self.registry.query()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].mass_lbs, 33000.0)
+
+    def test_custom_filter_mass_lbs_heavy(self):
+        """Custom filter for mass > 10000 should match heavy vehicle."""
+        results = self.registry.query(
+            custom_filters=[lambda m: m.mass_lbs is not None and m.mass_lbs > 10000]
+        )
+        self.assertEqual(len(results), 1)
+
+    def test_custom_filter_mass_lbs_light(self):
+        """Custom filter for mass < 5000 should not match heavy vehicle."""
+        results = self.registry.query(
+            custom_filters=[lambda m: m.mass_lbs is not None and m.mass_lbs < 5000]
+        )
+        self.assertEqual(len(results), 0)
+
+    def test_mass_lbs_in_model_info_dict(self):
+        """mass_lbs should roundtrip through to_dict/from_dict."""
+        results = self.registry.query()
+        info = results[0]
+        d = info.to_dict()
+        self.assertEqual(d["mass_lbs"], 33000.0)
+        restored = ModelInfo.from_dict(d)
+        self.assertEqual(restored.mass_lbs, 33000.0)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -171,3 +171,37 @@ class TestLocalRegistry(TestCase):
         # With a lower threshold, the partial match is accepted
         results_relaxed = self.registry.query(make="toyta", fuzzy_threshold=80)
         self.assertEqual(len(results_relaxed), 1)
+
+    def test_query_by_powertrain_type_exact(self):
+        """Exact powertrain type match should work."""
+        results = self.registry.query(powertrain_type="ICE")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].powertrain_type, "ICE")
+
+    def test_query_by_powertrain_type_case_insensitive(self):
+        """Powertrain type filtering should be case insensitive."""
+        results = self.registry.query(powertrain_type="ice")
+        self.assertEqual(len(results), 1)
+
+    def test_query_by_powertrain_type_no_match(self):
+        """Non-matching powertrain type should return empty results."""
+        results = self.registry.query(powertrain_type="BEV")
+        self.assertEqual(len(results), 0)
+
+    def test_query_by_powertrain_type_fuzzy(self):
+        """Fuzzy matching should work for powertrain type."""
+        results = self.registry.query(powertrain_type="IC")
+        self.assertEqual(len(results), 1)
+
+    def test_query_by_powertrain_type_fuzzy_disabled(self):
+        """With fuzzy=False, partial powertrain type should not match."""
+        results = self.registry.query(powertrain_type="IC", fuzzy=False)
+        self.assertEqual(len(results), 0)
+
+    def test_query_by_powertrain_type_combined_with_make(self):
+        """Powertrain type filter should combine with other filters."""
+        results = self.registry.query(make="toyota", powertrain_type="ICE")
+        self.assertEqual(len(results), 1)
+
+        results = self.registry.query(make="toyota", powertrain_type="BEV")
+        self.assertEqual(len(results), 0)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,6 +5,8 @@ from unittest import TestCase
 import pandas as pd
 
 import routee.powertrain as pt
+from routee.powertrain.core.drivetrain import Drivetrain
+from routee.powertrain.core.fuel_type import FuelType
 from routee.powertrain.io.archive import save_model_directory
 from routee.powertrain.registry.local import LocalRegistry
 from routee.powertrain.registry.model_id import ModelId, ModelInfo
@@ -366,3 +368,278 @@ class TestMassLbsModelConfig(TestCase):
         self.assertEqual(d["mass_lbs"], 33000.0)
         restored = ModelInfo.from_dict(d)
         self.assertEqual(restored.mass_lbs, 33000.0)
+
+
+class TestFuelTypeEnum(TestCase):
+    def test_from_string_roundtrip(self):
+        for member in FuelType:
+            self.assertEqual(FuelType.from_string(member.name), member)
+
+    def test_from_string_case_insensitive(self):
+        self.assertEqual(FuelType.from_string("diesel"), FuelType.DIESEL)
+        self.assertEqual(FuelType.from_string("Gasoline"), FuelType.GASOLINE)
+
+    def test_from_string_empty_returns_undefined(self):
+        self.assertEqual(FuelType.from_string(""), FuelType.UNDEFINED)
+        self.assertEqual(FuelType.from_string(None), FuelType.UNDEFINED)
+
+    def test_from_string_invalid_raises(self):
+        with self.assertRaises(TypeError):
+            FuelType.from_string("propane")
+
+
+class TestDrivetrainEnum(TestCase):
+    def test_from_string_roundtrip(self):
+        for member in Drivetrain:
+            self.assertEqual(Drivetrain.from_string(member.name), member)
+
+    def test_from_string_case_insensitive(self):
+        self.assertEqual(Drivetrain.from_string("fwd"), Drivetrain.FWD)
+        self.assertEqual(Drivetrain.from_string("Awd"), Drivetrain.AWD)
+
+    def test_from_string_empty_returns_undefined(self):
+        self.assertEqual(Drivetrain.from_string(""), Drivetrain.UNDEFINED)
+        self.assertEqual(Drivetrain.from_string(None), Drivetrain.UNDEFINED)
+
+    def test_from_string_invalid_raises(self):
+        with self.assertRaises(TypeError):
+            Drivetrain.from_string("6wd")
+
+
+class TestVehicleAttributeFields(TestCase):
+    def setUp(self):
+        import tempfile
+
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+        self.schema_version = "v2"
+
+        data_path = (
+            this_dir
+            / Path("routee-powertrain-test-data")
+            / Path("sample_train_data.csv")
+        )
+        df = pd.read_csv(data_path)
+        config = pt.ModelConfig(
+            vehicle_description="2020 Chevrolet Colorado 2WD Diesel",
+            powertrain_type=pt.PowertrainType.ICE,
+            feature_set=pt.FeatureSet(
+                features=[
+                    pt.DataColumn(name="speed_mph", units="mph"),
+                    pt.DataColumn(name="grade_dec", units="decimal"),
+                ],
+            ),
+            distance=pt.DataColumn(name="miles", units="miles"),
+            target=pt.TargetSet(
+                targets=[
+                    pt.DataColumn(
+                        name="gallons_fastsim",
+                        units="gallons_gasoline",
+                        constraints=pt.Constraints(lower=0.0, upper=100.0),
+                    )
+                ],
+            ),
+            make="Chevrolet",
+            model="colorado_2wd_diesel",
+            year=2020,
+            fuel_type=FuelType.DIESEL,
+            drivetrain=Drivetrain.FOURWD,
+            engine="4cyl",
+            trim="lt",
+        )
+        trainer = SklearnRandomForestTrainer()
+        model = trainer.train(df, config)
+
+        model_id = ModelId(
+            "chevrolet",
+            "colorado_2wd_diesel",
+            2020,
+            "default",
+            "grade_dec_speed_mph",
+            1,
+        )
+        rel_path = f"{self.schema_version}/{model_id.to_path()}"
+        full_path = self.root / rel_path
+        save_model_directory(model, full_path)
+
+        self.registry = LocalRegistry(
+            root=self.root, schema_version=self.schema_version
+        )
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp)
+
+    def test_fuel_type_in_model_info(self):
+        results = self.registry.query()
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].fuel_type, "DIESEL")
+
+    def test_drivetrain_in_model_info(self):
+        results = self.registry.query()
+        self.assertEqual(results[0].drivetrain, "FOURWD")
+
+    def test_engine_in_model_info(self):
+        results = self.registry.query()
+        self.assertEqual(results[0].engine, "4cyl")
+
+    def test_trim_in_model_info(self):
+        results = self.registry.query()
+        self.assertEqual(results[0].trim, "lt")
+
+    def test_query_by_fuel_type(self):
+        results = self.registry.query(fuel_type="DIESEL")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].fuel_type, "DIESEL")
+
+    def test_query_by_fuel_type_no_match(self):
+        results = self.registry.query(fuel_type="GASOLINE")
+        self.assertEqual(len(results), 0)
+
+    def test_query_by_drivetrain(self):
+        results = self.registry.query(drivetrain="FOURWD")
+        self.assertEqual(len(results), 1)
+
+    def test_query_by_drivetrain_no_match(self):
+        results = self.registry.query(drivetrain="FWD")
+        self.assertEqual(len(results), 0)
+
+    def test_query_by_engine(self):
+        results = self.registry.query(engine="4cyl")
+        self.assertEqual(len(results), 1)
+
+    def test_query_by_trim(self):
+        results = self.registry.query(trim="lt")
+        self.assertEqual(len(results), 1)
+
+    def test_query_combined_filters(self):
+        results = self.registry.query(fuel_type="DIESEL", drivetrain="FOURWD")
+        self.assertEqual(len(results), 1)
+
+        results = self.registry.query(fuel_type="DIESEL", drivetrain="FWD")
+        self.assertEqual(len(results), 0)
+
+    def test_model_info_roundtrip_dict(self):
+        results = self.registry.query()
+        info = results[0]
+        d = info.to_dict()
+        self.assertEqual(d["fuel_type"], "DIESEL")
+        self.assertEqual(d["drivetrain"], "FOURWD")
+        self.assertEqual(d["engine"], "4cyl")
+        self.assertEqual(d["trim"], "lt")
+        restored = ModelInfo.from_dict(d)
+        self.assertEqual(restored.fuel_type, "DIESEL")
+        self.assertEqual(restored.drivetrain, "FOURWD")
+        self.assertEqual(restored.engine, "4cyl")
+        self.assertEqual(restored.trim, "lt")
+
+    def test_model_config_string_coercion(self):
+        """ModelConfig should coerce string fuel_type/drivetrain to enums."""
+        config = pt.ModelConfig(
+            vehicle_description="test",
+            powertrain_type=pt.PowertrainType.ICE,
+            feature_set=pt.FeatureSet(
+                features=[pt.DataColumn(name="speed_mph", units="mph")]
+            ),
+            distance=pt.DataColumn(name="miles", units="miles"),
+            target=pt.TargetSet(
+                targets=[pt.DataColumn(name="gallons", units="gallons")]
+            ),
+            make="test",
+            model="test",
+            year=2020,
+            fuel_type="DIESEL",
+            drivetrain="AWD",
+        )
+        self.assertEqual(config.fuel_type, FuelType.DIESEL)
+        self.assertEqual(config.drivetrain, Drivetrain.AWD)
+
+    def test_model_config_backwards_compat(self):
+        """ModelConfig.from_dict should handle missing new fields gracefully."""
+        d = {
+            "vehicle_description": "test",
+            "powertrain_type": "ICE",
+            "feature_set": {
+                "features": [
+                    {
+                        "name": "speed_mph",
+                        "units": "mph",
+                        "dtype": "float32",
+                        "constraints": {"lower": None, "upper": None},
+                    }
+                ]
+            },
+            "distance": {
+                "name": "miles",
+                "units": "miles",
+                "dtype": "float32",
+                "constraints": {"lower": None, "upper": None},
+            },
+            "target": {
+                "targets": [
+                    {
+                        "name": "gallons",
+                        "units": "gallons",
+                        "dtype": "float32",
+                        "constraints": {"lower": None, "upper": None},
+                    }
+                ]
+            },
+            "make": "test",
+            "model": "test",
+            "year": 2020,
+        }
+        config = pt.ModelConfig.from_dict(d)
+        self.assertIsNone(config.fuel_type)
+        self.assertIsNone(config.drivetrain)
+        self.assertIsNone(config.engine)
+        self.assertIsNone(config.trim)
+
+    def test_model_info_from_dict_backwards_compat(self):
+        """ModelInfo.from_dict should handle missing new fields gracefully."""
+        d = {
+            "model_id": {
+                "make": "test",
+                "model": "test",
+                "year": 2020,
+                "variant": "default",
+                "feature_set_id": "speed_mph",
+                "version": 1,
+            },
+            "estimator_type": "ONNXEstimator",
+            "feature_names": ["speed_mph"],
+            "target_names": ["gallons"],
+            "powertrain_type": "ICE",
+            "vehicle_description": "test",
+        }
+        info = ModelInfo.from_dict(d)
+        self.assertIsNone(info.fuel_type)
+        self.assertIsNone(info.drivetrain)
+        self.assertIsNone(info.engine)
+        self.assertIsNone(info.trim)
+
+    def test_none_fields_excluded_from_filter(self):
+        """Models with None fuel_type should not match a fuel_type filter."""
+        from routee.powertrain.registry.filtering import filter_models
+
+        info_with = ModelInfo(
+            model_id=ModelId("a", "b", 2020, "default", "speed", 1),
+            estimator_type="ONNXEstimator",
+            feature_names=["speed"],
+            target_names=["gal"],
+            powertrain_type="ICE",
+            vehicle_description="test",
+            fuel_type="DIESEL",
+        )
+        info_without = ModelInfo(
+            model_id=ModelId("a", "c", 2020, "default", "speed", 1),
+            estimator_type="ONNXEstimator",
+            feature_names=["speed"],
+            target_names=["gal"],
+            powertrain_type="ICE",
+            vehicle_description="test",
+        )
+        results = filter_models([info_with, info_without], fuel_type="DIESEL")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].fuel_type, "DIESEL")


### PR DESCRIPTION
Adds in additional optional information to the model metadata including:

 - mass
 - fuel type (gas, diesel, electricity, etc)
 - drivetrain (FWD, 4WD, etc)
 - engine information (i.e. 4cy, 1.5L, etc)
 - trim

This also allows a user to query models based on this information and add the ability to specify custom filtering functions like: `lambda mi: mi.mass_lbs > 10000`