### PR TITLE
Add version strategy

### DIFF
--- a/routee/powertrain/io/load.py
+++ b/routee/powertrain/io/load.py
@@ -5,6 +5,8 @@ from typing import Callable, List, Optional, Sequence, Union
 import pandas as pd
 
 from routee.powertrain.core.model import Model
+from routee.powertrain.core.year import parse_year
+from routee.powertrain.registry.filtering import VersionStrategy
 from routee.powertrain.registry.model_id import ModelId, ModelInfo
 from routee.powertrain.registry.registry import ModelRegistry
 from routee.powertrain.resources.sample_routes import sample_route_dir
@@ -14,6 +16,7 @@ log = logging.getLogger(__name__)
 
 def list_available_models(
     registry: Optional[ModelRegistry] = None,
+    version_strategy: VersionStrategy = "latest",
 ) -> List[ModelId]:
     """
     Returns a list of model identifiers available in the registry.
@@ -25,15 +28,18 @@ def list_available_models(
 
     Args:
         registry: a ModelRegistry instance; defaults to get_default_registry()
+        version_strategy: ``"latest"`` (default) returns only the highest
+            version per (make, model, year, config_slug) group; ``"all"``
+            returns every versioned identifier.
 
-    Returns: list of ModelId for every model in the registry
+    Returns: list of ModelId matching the strategy
     """
     if registry is None:
         from routee.powertrain.registry.default import get_default_registry
 
         registry = get_default_registry()
 
-    return registry.list_models()
+    return registry.list_models(version_strategy=version_strategy)
 
 
 def query_available_models(
@@ -47,6 +53,8 @@ def query_available_models(
     drivetrain: Optional[str] = None,
     engine: Optional[str] = None,
     trim: Optional[str] = None,
+    version: Optional[int] = None,
+    version_strategy: VersionStrategy = "latest",
     custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
     registry: Optional[ModelRegistry] = None,
     fuzzy: bool = True,
@@ -70,6 +78,12 @@ def query_available_models(
         drivetrain: filter by drivetrain (e.g. "FWD", "RWD", "AWD")
         engine: filter by engine specification (e.g. "4cyl", "2.0tdi")
         trim: filter by trim level (e.g. "sport", "active")
+        version: pin results to an exact version (e.g. 2). When set,
+            ``version_strategy`` is ignored.
+        version_strategy: how to collapse multiple versions of the same
+            model. ``"latest"`` (default) keeps only the highest version
+            per (make, model, year, config_slug) group; ``"all"`` returns
+            every version. Ignored when ``version`` is specified.
         custom_filters: optional list of callables that accept a ModelInfo
             and return True to keep the model or False to exclude it.
             For example: ``[lambda m: m.mass_lbs is not None and m.mass_lbs > 10000]``
@@ -95,9 +109,57 @@ def query_available_models(
         drivetrain=drivetrain,
         engine=engine,
         trim=trim,
+        version=version,
+        version_strategy=version_strategy,
         custom_filters=custom_filters,
         fuzzy=fuzzy,
         fuzzy_threshold=fuzzy_threshold,
+    )
+
+
+def _resolve_load_target(name_or_path: str, registry: ModelRegistry) -> ModelId:
+    """Resolve a string model identifier to a concrete ModelId.
+
+    Accepts two forms:
+
+    - ``<make>/<model>/<year>/<config_slug>/v<N>`` — explicit version.
+    - ``<make>/<model>/<year>/<config_slug>`` — latest version is picked via
+      a ``fuzzy=False`` registry query.
+
+    Raises ``ValueError`` with an actionable message on unknown shapes,
+    zero matches, or ambiguous matches.
+    """
+    parts = [p for p in name_or_path.strip("/").split("/") if p]
+    if len(parts) == 5:
+        return ModelId.from_path(name_or_path)
+    if len(parts) == 4:
+        make, model, year_str, config_slug = parts
+        parsed_year = parse_year(year_str)
+        year_filter = parsed_year if isinstance(parsed_year, int) else None
+        hits = registry.query(
+            make=make,
+            model=model,
+            year=year_filter,
+            config_slug=config_slug,
+            fuzzy=False,
+            version_strategy="latest",
+        )
+        # If the path carries a year range, query() can't filter on it
+        # via year_contains (which only accepts int), so drop any hits
+        # whose stored year doesn't exactly match the requested shape.
+        hits = [h for h in hits if h.model_id.year == parsed_year]
+        if len(hits) == 1:
+            return hits[0].model_id
+        if not hits:
+            raise ValueError(f"No model found for '{name_or_path}'")
+        raise ValueError(
+            f"Ambiguous partial id '{name_or_path}' — matched {len(hits)} models: "
+            + ", ".join(str(h.model_id) for h in hits)
+        )
+    raise ValueError(
+        f"Could not parse '{name_or_path}'. Expected either "
+        "'<make>/<model>/<year>/<config_slug>/v<N>' (explicit version) or "
+        "'<make>/<model>/<year>/<config_slug>' (latest)."
     )
 
 
@@ -114,7 +176,8 @@ def load_model(
        directory (containing ``metadata.json``), ``.zip`` archive,
        or ``.tar.gz`` archive on disk.
     2. **Registry ModelId** — pass a ``ModelId`` object or model id path to fetch from a
-       registry (uses the default registry if none is provided).
+       registry (uses the default registry if none is provided). String
+       paths may omit the ``v<N>`` segment to load the latest version.
 
     Args:
         name_or_path: file/directory path or ModelId
@@ -137,8 +200,11 @@ def load_model(
     >>> mid = ModelId("toyota", "camry", 2016, "rf_default", 1)
     >>> model = pt.load_model(mid)
     >>>
-    >>> mid_str = "toyota/camry/2016/rf_default/v1"
-    >>> model = pt.load_model(mid_str)
+    >>> # explicit version
+    >>> model = pt.load_model("toyota/camry/2016/rf_default/v1")
+    >>>
+    >>> # latest version (no version segment)
+    >>> model = pt.load_model("toyota/camry/2016/rf_default")
 
     """
     # First assume the model is local
@@ -156,12 +222,9 @@ def load_model(
     if isinstance(name_or_path, ModelId):
         return registry.load(name_or_path)
 
-    if isinstance(name_or_path, str):
-        try:
-            mid = ModelId.from_path(name_or_path)
-            return registry.load(mid)
-        except ValueError:
-            pass
+    if isinstance(name_or_path, (str, Path)):
+        mid = _resolve_load_target(str(name_or_path), registry)
+        return registry.load(mid)
 
     raise ValueError(
         f"Could not load model: {name_or_path}. "

--- a/routee/powertrain/registry/filtering.py
+++ b/routee/powertrain/registry/filtering.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Callable, List, Optional, Sequence
+from typing import Callable, Dict, List, Literal, Optional, Sequence, Tuple
 
 from rapidfuzz import fuzz
 
-from routee.powertrain.core.year import year_contains
-from routee.powertrain.registry.model_id import ModelInfo
+from routee.powertrain.core.year import serialize_year, year_contains
+from routee.powertrain.registry.model_id import ModelId, ModelInfo
+
+VersionStrategy = Literal["latest", "all"]
 
 
 def _matches(query: str, candidate: str, fuzzy: bool, threshold: int) -> bool:
@@ -14,6 +16,16 @@ def _matches(query: str, candidate: str, fuzzy: bool, threshold: int) -> bool:
     if not fuzzy:
         return candidate == query_lower
     return fuzz.WRatio(query_lower, candidate) >= threshold
+
+
+def _group_key(model_id: ModelId) -> Tuple[str, str, object, str]:
+    """Build a hashable grouping key that collapses versions of the same model."""
+    return (
+        model_id.make,
+        model_id.model,
+        serialize_year(model_id.year),
+        model_id.config_slug,
+    )
 
 
 def filter_models(
@@ -28,6 +40,8 @@ def filter_models(
     drivetrain: Optional[str] = None,
     engine: Optional[str] = None,
     trim: Optional[str] = None,
+    version: Optional[int] = None,
+    version_strategy: VersionStrategy = "latest",
     custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
     fuzzy: bool = True,
     fuzzy_threshold: int = 80,
@@ -38,6 +52,11 @@ def filter_models(
 
     ``feature_names`` filters to models whose ``feature_names`` contains every
     listed name (subset match, exact column name).
+
+    ``version`` pins results to an exact version. When set, ``version_strategy``
+    is ignored. ``version_strategy`` collapses multiple versions of the same
+    ``(make, model, year, config_slug)`` group to the highest version when set
+    to ``"latest"`` (default), or returns all versions when set to ``"all"``.
     """
     results = models
     if make is not None:
@@ -103,7 +122,39 @@ def filter_models(
             if m.trim is not None
             and _matches(trim, m.trim.lower(), fuzzy, fuzzy_threshold)
         ]
+    if version is not None:
+        results = [m for m in results if m.model_id.version == version]
     if custom_filters is not None:
         for fn in custom_filters:
             results = [m for m in results if fn(m)]
-    return results
+
+    # An explicit version filter overrides the strategy — the caller is
+    # asking for exactly that version.
+    effective_strategy: VersionStrategy = (
+        "all" if version is not None else version_strategy
+    )
+    if effective_strategy == "all":
+        return results
+    if effective_strategy == "latest":
+        best: Dict[Tuple[str, str, object, str], ModelInfo] = {}
+        for m in results:
+            key = _group_key(m.model_id)
+            current = best.get(key)
+            if current is None or m.model_id.version > current.model_id.version:
+                best[key] = m
+        return list(best.values())
+    raise ValueError(
+        f"Unknown version_strategy '{version_strategy}'. "
+        "Expected one of: 'latest', 'all'."
+    )
+
+
+def latest_model_ids(ids: List[ModelId]) -> List[ModelId]:
+    """Reduce a list of ModelIds to the highest version per model group."""
+    best: Dict[Tuple[str, str, object, str], ModelId] = {}
+    for mid in ids:
+        key = _group_key(mid)
+        current = best.get(key)
+        if current is None or mid.version > current.version:
+            best[key] = mid
+    return list(best.values())

--- a/routee/powertrain/registry/local.py
+++ b/routee/powertrain/registry/local.py
@@ -12,7 +12,11 @@ from routee.powertrain.io.archive import (
     METADATA_FILENAME,
 )
 from routee.powertrain.core.metadata import SCHEMA_VERSION_STRING
-from routee.powertrain.registry.filtering import filter_models
+from routee.powertrain.registry.filtering import (
+    VersionStrategy,
+    filter_models,
+    latest_model_ids,
+)
 from routee.powertrain.registry.model_id import ModelId, ModelInfo
 from routee.powertrain.registry.registry import ModelRegistry, _resolve_model_id
 
@@ -130,7 +134,10 @@ class LocalRegistry(ModelRegistry):
                 continue  # skip malformed entries
         return results
 
-    def list_models(self) -> List[ModelId]:
+    def list_models(
+        self,
+        version_strategy: VersionStrategy = "latest",
+    ) -> List[ModelId]:
         schema_root = self._schema_root
         if not schema_root.exists():
             return []
@@ -143,6 +150,8 @@ class LocalRegistry(ModelRegistry):
                 results.append(model_id)
             except Exception:
                 continue
+        if version_strategy == "latest":
+            return latest_model_ids(results)
         return results
 
     def query(
@@ -157,13 +166,14 @@ class LocalRegistry(ModelRegistry):
         drivetrain: Optional[str] = None,
         engine: Optional[str] = None,
         trim: Optional[str] = None,
+        version: Optional[int] = None,
+        version_strategy: VersionStrategy = "latest",
         custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
-        results = self._scan_models()
         return filter_models(
-            results,
+            self._scan_models(),
             make=make,
             model=model,
             year=year,
@@ -174,6 +184,8 @@ class LocalRegistry(ModelRegistry):
             drivetrain=drivetrain,
             engine=engine,
             trim=trim,
+            version=version,
+            version_strategy=version_strategy,
             custom_filters=custom_filters,
             fuzzy=fuzzy,
             fuzzy_threshold=fuzzy_threshold,

--- a/routee/powertrain/registry/registry.py
+++ b/routee/powertrain/registry/registry.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Callable, List, Optional, Sequence, Union
 
 from routee.powertrain.core.model import Model
+from routee.powertrain.registry.filtering import VersionStrategy
 from routee.powertrain.registry.model_id import ModelId, ModelInfo
 
 
@@ -36,6 +37,8 @@ class ModelRegistry(ABC):
         drivetrain: Optional[str] = None,
         engine: Optional[str] = None,
         trim: Optional[str] = None,
+        version: Optional[int] = None,
+        version_strategy: VersionStrategy = "latest",
         custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
@@ -58,6 +61,12 @@ class ModelRegistry(ABC):
             drivetrain: filter by drivetrain (e.g. "FWD", "RWD", "AWD")
             engine: filter by engine specification (e.g. "4cyl", "2.0tdi")
             trim: filter by trim level (e.g. "sport", "active")
+            version: pin results to an exact version (e.g. 2). When set,
+                ``version_strategy`` is ignored.
+            version_strategy: how to collapse multiple versions of the same
+                model. ``"latest"`` (default) keeps only the highest version
+                per (make, model, year, config_slug) group; ``"all"`` returns
+                every version. Ignored when ``version`` is specified.
             custom_filters: optional list of callables that accept a ModelInfo
                 and return True to keep the model or False to exclude it
             fuzzy: if True, use fuzzy string matching for string
@@ -80,14 +89,22 @@ class ModelRegistry(ABC):
         """
 
     @abstractmethod
-    def list_models(self) -> List[ModelId]:
+    def list_models(
+        self,
+        version_strategy: VersionStrategy = "latest",
+    ) -> List[ModelId]:
         """
-        List all model identifiers in the registry.
+        List model identifiers in the registry.
 
         This is a lightweight operation that returns only the model
         paths/identifiers without fetching any metadata or binaries.
 
-        Returns: list of ModelId for every model in the registry
+        Args:
+            version_strategy: ``"latest"`` (default) returns only the highest
+                version per (make, model, year, config_slug) group; ``"all"``
+                returns every versioned identifier.
+
+        Returns: list of ModelId matching the strategy
         """
 
     @abstractmethod

--- a/routee/powertrain/registry/s3.py
+++ b/routee/powertrain/registry/s3.py
@@ -7,12 +7,16 @@ from typing import Callable, List, Optional, Sequence, Union
 
 from routee.powertrain.core.metadata import SCHEMA_VERSION_STRING
 from routee.powertrain.core.model import Model
-from routee.powertrain.core.year import parse_year, year_contains
+from routee.powertrain.core.year import parse_year
 from routee.powertrain.io.archive import (
     _model_from_metadata_and_bytes,
     METADATA_FILENAME,
 )
-from routee.powertrain.registry.filtering import _matches, filter_models
+from routee.powertrain.registry.filtering import (
+    VersionStrategy,
+    filter_models,
+    latest_model_ids,
+)
 from routee.powertrain.registry.model_id import ModelId, ModelInfo
 from routee.powertrain.registry.registry import ModelRegistry, _resolve_model_id
 from routee.powertrain.registry.default import (
@@ -97,19 +101,26 @@ def _model_info_from_metadata(
     )
 
 
+class IndexMissingError(RuntimeError):
+    """Raised when ``index.json`` is missing or unreadable at the schema root."""
+
+
 class S3Registry(ModelRegistry):
     """
     A model registry backed by a public S3 bucket.
 
     Models are stored as directories containing ``metadata.json`` and a
-    binary model file.  Discovery uses ``ListObjectsV2`` to scan for
-    ``metadata.json`` keys under the schema prefix.
+    binary model file. Discovery requires an ``index.json`` at the schema
+    root; build it with :func:`build_index`.
 
     Bucket layout::
 
-        s3://<bucket>/<root_prefix>/<schema_version>/<make>/<model>/<year>/<config_slug>/v<N>/
-            metadata.json
-            model.onnx
+        s3://<bucket>/<root_prefix>/<schema_version>/
+            index.json
+            <make>/<model>/<year>/<config_slug>/v<N>/
+                metadata.json
+                model.onnx
+
     Args:
         bucket: S3 bucket name
         schema_version: schema version to use (default "v2")
@@ -155,79 +166,8 @@ class S3Registry(ModelRegistry):
             return f"{self.root_prefix}/{self.schema_version}"
         return self.schema_version
 
-    def _list_children(self, prefix: str) -> List[str]:
-        """List immediate child directory names under an S3 prefix.
-
-        Uses ``Delimiter='/'`` so S3 returns ``CommonPrefixes`` without
-        downloading any objects.  Handles pagination.
-
-        Args:
-            prefix: S3 key prefix ending with ``/``
-
-        Returns:
-            List of child directory names (without trailing ``/``)
-        """
-        client = self._get_client()
-        children: List[str] = []
-        paginator = client.get_paginator("list_objects_v2")
-        for page in paginator.paginate(
-            Bucket=self.bucket, Prefix=prefix, Delimiter="/"
-        ):
-            for cp in page.get("CommonPrefixes", []):
-                # cp["Prefix"] looks like "<prefix><child>/"
-                child = cp["Prefix"][len(prefix) :].rstrip("/")
-                if child:
-                    children.append(child)
-        return children
-
-    def _narrow_prefixes(
-        self,
-        prefixes: List[str],
-        query_value: Optional[str],
-        fuzzy: bool,
-        threshold: int,
-        is_year: bool = False,
-        year_query: Optional[int] = None,
-    ) -> List[str]:
-        """Expand prefixes by one hierarchy level, optionally filtering.
-
-        For each prefix, lists child directories via S3 and applies
-        fuzzy or exact matching against ``query_value`` to narrow the
-        result set.  For the year level, set ``is_year=True`` and pass
-        the numeric year as ``year_query`` to use ``year_contains``.
-
-        Args:
-            prefixes: S3 key prefixes to expand
-            query_value: string filter (make, model, etc.) or None
-            fuzzy: whether to use fuzzy string matching
-            threshold: fuzzy match threshold (0–100)
-            is_year: if True, filter using ``year_contains`` instead
-            year_query: numeric year used when ``is_year`` is True
-
-        Returns:
-            List of narrowed S3 prefixes (one level deeper)
-        """
-        next_prefixes: List[str] = []
-        for prefix in prefixes:
-            children = self._list_children(prefix)
-            for child in children:
-                child_prefix = f"{prefix}{child}/"
-                if is_year and year_query is not None:
-                    try:
-                        child_year = parse_year(child)
-                    except (ValueError, TypeError):
-                        continue
-                    if year_contains(child_year, year_query):
-                        next_prefixes.append(child_prefix)
-                elif query_value is not None:
-                    if _matches(query_value, child.lower(), fuzzy, threshold):
-                        next_prefixes.append(child_prefix)
-                else:
-                    next_prefixes.append(child_prefix)
-        return next_prefixes
-
     def _list_metadata_keys(self) -> List[str]:
-        """List all metadata.json keys under the schema prefix using pagination."""
+        """List all metadata.json keys under the schema prefix (for build_index)."""
         client = self._get_client()
         prefix = f"{self._s3_prefix()}/"
         keys: List[str] = []
@@ -239,53 +179,36 @@ class S3Registry(ModelRegistry):
                     keys.append(key)
         return keys
 
-    def _fetch_index(self) -> Optional[List[ModelInfo]]:
-        """Fetch the index.json from the bucket if it exists."""
+    def _fetch_index(self) -> List[ModelInfo]:
+        """Fetch and parse the index.json at the schema root.
+
+        Raises:
+            IndexMissingError: if the index is missing or unreadable. Callers
+                should surface this with guidance to run ``build_index``.
+        """
         key = f"{self._s3_prefix()}/{INDEX_FILENAME}"
         try:
             data = self._fetch_bytes(key)
+        except Exception as exc:
+            raise IndexMissingError(
+                f"Could not read '{key}' from s3://{self.bucket}. "
+                "The S3 registry requires an index.json at the schema root — "
+                "run routee.powertrain.registry.s3.build_index to generate one."
+            ) from exc
+        try:
             index_dict = json.loads(data)
             return [ModelInfo.from_dict(m) for m in index_dict.get("models", [])]
-        except Exception:
-            return None
+        except Exception as exc:
+            raise IndexMissingError(f"Could not parse index at '{key}': {exc}") from exc
 
-    def _scan_models(self) -> List[ModelInfo]:
-        """Scan the bucket for all models and return their metadata."""
-        index = self._fetch_index()
-        if index is not None:
-            return index
-
-        results: List[ModelInfo] = []
-        for key in self._list_metadata_keys():
-            try:
-                model_id = _parse_model_id_from_key(
-                    key, self.schema_version, self.root_prefix
-                )
-                data = self._fetch_bytes(key)
-                metadata_dict = json.loads(data)
-                # path is the directory prefix (key without /metadata.json)
-                dir_key = key[: -len(f"/{METADATA_FILENAME}")]
-                info = _model_info_from_metadata(metadata_dict, model_id, dir_key)
-                results.append(info)
-            except Exception:
-                continue
-        return results
-
-    def list_models(self) -> List[ModelId]:
-        index = self._fetch_index()
-        if index is not None:
-            return [m.model_id for m in index]
-
-        results: List[ModelId] = []
-        for key in self._list_metadata_keys():
-            try:
-                model_id = _parse_model_id_from_key(
-                    key, self.schema_version, self.root_prefix
-                )
-                results.append(model_id)
-            except Exception:
-                continue
-        return results
+    def list_models(
+        self,
+        version_strategy: VersionStrategy = "latest",
+    ) -> List[ModelId]:
+        ids = [m.model_id for m in self._fetch_index()]
+        if version_strategy == "latest":
+            return latest_model_ids(ids)
+        return ids
 
     def query(
         self,
@@ -299,132 +222,30 @@ class S3Registry(ModelRegistry):
         drivetrain: Optional[str] = None,
         engine: Optional[str] = None,
         trim: Optional[str] = None,
+        version: Optional[int] = None,
+        version_strategy: VersionStrategy = "latest",
         custom_filters: Optional[Sequence[Callable[[ModelInfo], bool]]] = None,
         fuzzy: bool = True,
         fuzzy_threshold: int = 80,
     ) -> List[ModelInfo]:
-        index = self._fetch_index()
-        if index is not None:
-            return filter_models(
-                index,
-                make=make,
-                model=model,
-                year=year,
-                config_slug=config_slug,
-                feature_names=feature_names,
-                powertrain_type=powertrain_type,
-                fuel_type=fuel_type,
-                drivetrain=drivetrain,
-                engine=engine,
-                trim=trim,
-                custom_filters=custom_filters,
-                fuzzy=fuzzy,
-                fuzzy_threshold=fuzzy_threshold,
-            )
-
-        has_filters = any(
-            v is not None
-            for v in (
-                make,
-                model,
-                year,
-                config_slug,
-                feature_names,
-                powertrain_type,
-                fuel_type,
-                drivetrain,
-                engine,
-                trim,
-            )
+        return filter_models(
+            self._fetch_index(),
+            make=make,
+            model=model,
+            year=year,
+            config_slug=config_slug,
+            feature_names=feature_names,
+            powertrain_type=powertrain_type,
+            fuel_type=fuel_type,
+            drivetrain=drivetrain,
+            engine=engine,
+            trim=trim,
+            version=version,
+            version_strategy=version_strategy,
+            custom_filters=custom_filters,
+            fuzzy=fuzzy,
+            fuzzy_threshold=fuzzy_threshold,
         )
-        has_custom_filters = custom_filters is not None and len(custom_filters) > 0
-        if not has_filters and not has_custom_filters:
-            return self._scan_models()
-
-        # Walk the S3 hierarchy level-by-level, narrowing at each step.
-        # Levels: make / model / year / config_slug / version
-        prefixes = [f"{self._s3_prefix()}/"]
-
-        # Level 1: make
-        prefixes = self._narrow_prefixes(prefixes, make, fuzzy, fuzzy_threshold)
-        # Level 2: model
-        prefixes = self._narrow_prefixes(prefixes, model, fuzzy, fuzzy_threshold)
-        # Level 3: year
-        prefixes = self._narrow_prefixes(
-            prefixes,
-            None,
-            fuzzy,
-            fuzzy_threshold,
-            is_year=(year is not None),
-            year_query=year,
-        )
-        # Level 4: config_slug
-        prefixes = self._narrow_prefixes(prefixes, config_slug, fuzzy, fuzzy_threshold)
-        # Level 5: version (expand all)
-        prefixes = self._narrow_prefixes(prefixes, None, fuzzy, fuzzy_threshold)
-
-        required_features = (
-            {n.lower() for n in feature_names} if feature_names else None
-        )
-
-        # Fetch metadata for narrowed results
-        results: List[ModelInfo] = []
-        for prefix in prefixes:
-            meta_key = f"{prefix}{METADATA_FILENAME}"
-            try:
-                model_id = _parse_model_id_from_key(
-                    meta_key, self.schema_version, self.root_prefix
-                )
-                data = self._fetch_bytes(meta_key)
-                metadata_dict = json.loads(data)
-                dir_key = prefix.rstrip("/")
-                info = _model_info_from_metadata(metadata_dict, model_id, dir_key)
-                # Apply metadata-level filters that can't be narrowed
-                # via the S3 directory hierarchy.
-                if required_features is not None and not required_features.issubset(
-                    {fn.lower() for fn in info.feature_names}
-                ):
-                    continue
-                if powertrain_type is not None and not _matches(
-                    powertrain_type,
-                    info.powertrain_type.lower(),
-                    fuzzy,
-                    fuzzy_threshold,
-                ):
-                    continue
-                if fuel_type is not None and (
-                    info.fuel_type is None
-                    or not _matches(
-                        fuel_type, info.fuel_type.lower(), fuzzy, fuzzy_threshold
-                    )
-                ):
-                    continue
-                if drivetrain is not None and (
-                    info.drivetrain is None
-                    or not _matches(
-                        drivetrain,
-                        info.drivetrain.lower(),
-                        fuzzy,
-                        fuzzy_threshold,
-                    )
-                ):
-                    continue
-                if engine is not None and (
-                    info.engine is None
-                    or not _matches(engine, info.engine.lower(), fuzzy, fuzzy_threshold)
-                ):
-                    continue
-                if trim is not None and (
-                    info.trim is None
-                    or not _matches(trim, info.trim.lower(), fuzzy, fuzzy_threshold)
-                ):
-                    continue
-                if custom_filters and not all(fn(info) for fn in custom_filters):
-                    continue
-                results.append(info)
-            except Exception:
-                continue
-        return results
 
     def load(self, model_id: Union[str, ModelId]) -> Model:
         model_id = _resolve_model_id(model_id)
@@ -471,7 +292,6 @@ def build_index(
     log = logging.getLogger(__name__)
     log.info("Scanning s3://%s/%s for models...", bucket, registry._s3_prefix())
 
-    # We use _list_metadata_keys directly to avoid using an old index if it exists
     models = []
     for key in registry._list_metadata_keys():
         try:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -276,6 +276,162 @@ class TestLocalRegistry(TestCase):
         self.assertEqual(len(results), 1)
 
 
+class TestVersionStrategyAndPartialLoad(TestCase):
+    """Multi-version fixture exercising version_strategy, version filter,
+    and partial-id resolution in load_model."""
+
+    def setUp(self):
+        import tempfile
+
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+        self.schema_version = "v2"
+
+        data_path = (
+            this_dir
+            / Path("routee-powertrain-test-data")
+            / Path("sample_train_data.csv")
+        )
+        df = pd.read_csv(data_path)
+        config = pt.ModelConfig(
+            vehicle_description="2016 Toyota Camry 4cyl FWD",
+            powertrain_type=pt.PowertrainType.ICE,
+            feature_set=pt.FeatureSet(
+                features=[
+                    pt.DataColumn(name="speed_mph", units="mph"),
+                    pt.DataColumn(name="grade_dec", units="decimal"),
+                ],
+            ),
+            distance=pt.DataColumn(name="miles", units="miles"),
+            target=pt.TargetSet(
+                targets=[
+                    pt.DataColumn(
+                        name="gallons_fastsim",
+                        units="gallons_gasoline",
+                        constraints=pt.Constraints(lower=0.0, upper=100.0),
+                    )
+                ],
+            ),
+            make="Toyota",
+            model="Camry_4cyl_fwd",
+            year=2016,
+        )
+        trainer = SklearnRandomForestTrainer()
+        self.model = trainer.train(df, config)
+        self.df = df
+
+        # Save three versions of the same (make, model, year, config_slug).
+        for version in (1, 2, 3):
+            mid = ModelId("toyota", "camry_4cyl_fwd", 2016, "rf_default", version)
+            save_model_directory(
+                self.model, self.root / self.schema_version / mid.to_path()
+            )
+
+        # Also save a second config_slug so we can test ambiguity safeguards.
+        mid_other = ModelId("toyota", "camry_4cyl_fwd", 2016, "rf_speed_grade", 1)
+        save_model_directory(
+            self.model, self.root / self.schema_version / mid_other.to_path()
+        )
+
+        self.registry = LocalRegistry(
+            root=self.root, schema_version=self.schema_version
+        )
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmp)
+
+    def test_query_default_returns_latest_only(self):
+        """Default strategy keeps only the highest version per group."""
+        results = self.registry.query(make="toyota", model="camry_4cyl_fwd")
+        # rf_default v3 + rf_speed_grade v1 = 2 groups
+        self.assertEqual(len(results), 2)
+        versions_by_slug = {r.model_id.config_slug: r.model_id.version for r in results}
+        self.assertEqual(versions_by_slug["rf_default"], 3)
+        self.assertEqual(versions_by_slug["rf_speed_grade"], 1)
+
+    def test_query_version_strategy_all(self):
+        """version_strategy='all' returns every version."""
+        results = self.registry.query(
+            make="toyota",
+            config_slug="rf_default",
+            version_strategy="all",
+        )
+        self.assertEqual(len(results), 3)
+        versions = sorted(r.model_id.version for r in results)
+        self.assertEqual(versions, [1, 2, 3])
+
+    def test_query_version_filter_exact(self):
+        """version=2 returns only v2 of matching models."""
+        results = self.registry.query(config_slug="rf_default", version=2)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].model_id.version, 2)
+
+    def test_query_version_filter_overrides_strategy(self):
+        """When version is set, version_strategy should be ignored."""
+        results = self.registry.query(
+            config_slug="rf_default",
+            version=1,
+            version_strategy="latest",
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].model_id.version, 1)
+
+    def test_list_models_default_latest(self):
+        """list_models default keeps only the highest version per group."""
+        ids = self.registry.list_models()
+        self.assertEqual(len(ids), 2)
+        by_slug = {mid.config_slug: mid.version for mid in ids}
+        self.assertEqual(by_slug["rf_default"], 3)
+
+    def test_list_models_all(self):
+        """list_models with version_strategy='all' returns every version."""
+        ids = self.registry.list_models(version_strategy="all")
+        self.assertEqual(len(ids), 4)
+
+    def test_load_model_partial_id_resolves_latest(self):
+        """A 4-segment string loads the highest-versioned model."""
+        loaded = pt.load_model(
+            "toyota/camry_4cyl_fwd/2016/rf_default", registry=self.registry
+        )
+        r1 = self.model.predict(self.df)
+        r2 = loaded.predict(self.df)
+        self.assertTrue(
+            math.isclose(r1.gallons_fastsim.sum(), r2.gallons_fastsim.sum())
+        )
+
+    def test_load_model_explicit_version_still_works(self):
+        """A 5-segment path pins the specific version."""
+        loaded = pt.load_model(
+            "toyota/camry_4cyl_fwd/2016/rf_default/v1", registry=self.registry
+        )
+        self.assertIsNotNone(loaded)
+
+    def test_load_model_partial_id_no_match_raises(self):
+        """Partial id with no match raises ValueError naming the path."""
+        with self.assertRaises(ValueError) as ctx:
+            pt.load_model(
+                "toyota/camry_4cyl_fwd/2016/does_not_exist", registry=self.registry
+            )
+        self.assertIn("No model found", str(ctx.exception))
+
+    def test_load_model_partial_id_uses_exact_match_not_fuzzy(self):
+        """Partial id resolver must use fuzzy=False to avoid neighbor matches."""
+        # 'rf' would fuzzy-match both 'rf_default' and 'rf_speed_grade', but
+        # the resolver pins fuzzy=False, so no model should match.
+        with self.assertRaises(ValueError) as ctx:
+            pt.load_model("toyota/camry_4cyl_fwd/2016/rf", registry=self.registry)
+        self.assertIn("No model found", str(ctx.exception))
+
+    def test_load_model_bad_segment_count_raises(self):
+        """A path with neither 4 nor 5 segments raises with a helpful message."""
+        with self.assertRaises(ValueError) as ctx:
+            pt.load_model("toyota/camry", registry=self.registry)
+        msg = str(ctx.exception)
+        self.assertIn("<make>/<model>/<year>/<config_slug>", msg)
+
+
 class TestMassLbsModelConfig(TestCase):
     def setUp(self):
         import tempfile

--- a/tests/test_s3_registry.py
+++ b/tests/test_s3_registry.py
@@ -4,7 +4,7 @@ import json
 from unittest import TestCase
 from unittest.mock import MagicMock
 
-from routee.powertrain.registry.s3 import S3Registry
+from routee.powertrain.registry.s3 import IndexMissingError, S3Registry
 
 ROOT = "routee-powertrain-model-library"
 SCHEMA = "v2"
@@ -42,314 +42,234 @@ def _fake_metadata(
     }
 
 
-def _common_prefixes(*children: str, prefix: str = "") -> dict:
-    """Build a single page of ListObjectsV2 response with CommonPrefixes."""
-    return {
-        "CommonPrefixes": [{"Prefix": f"{prefix}{c}/"} for c in children],
-    }
-
-
-class _MockPaginator:
-    """Paginator that returns pre-configured pages keyed by (Prefix, Delimiter)."""
-
-    def __init__(self, pages_by_prefix: dict):
-        self.pages_by_prefix = pages_by_prefix
-
-    def paginate(self, Bucket, Prefix, Delimiter=None):
-        key = Prefix
-        return self.pages_by_prefix.get(key, [])
-
-
 class _MockClient:
-    """Minimal mock S3 client supporting get_paginator and get_object."""
+    """Minimal mock S3 client supporting get_object with a preloaded object map."""
 
-    def __init__(self, pages_by_prefix: dict, objects: dict | None = None):
-        self._paginator = _MockPaginator(pages_by_prefix)
+    def __init__(self, objects: dict | None = None):
         self._objects = objects or {}
 
-    def get_paginator(self, operation_name):
-        return self._paginator
-
     def get_object(self, Bucket, Key):
+        if Key not in self._objects:
+            error = KeyError(Key)
+            raise error
         body = MagicMock()
-        body.read.return_value = self._objects.get(Key, b"")
+        body.read.return_value = self._objects[Key]
         return {"Body": body}
 
 
-def _build_registry(pages_by_prefix, objects=None):
-    """Create an S3Registry with a mock client pre-injected."""
+def _index_entry(
+    make: str,
+    model: str,
+    year: int,
+    config_slug: str,
+    version: int,
+    powertrain: str = "ICE",
+    feature_names: list | None = None,
+    fuel_type: str | None = None,
+) -> dict:
+    return {
+        "model_id": {
+            "make": make,
+            "model": model,
+            "year": year,
+            "config_slug": config_slug,
+            "version": version,
+        },
+        "estimator_type": "ONNXEstimator",
+        "feature_names": feature_names or ["speed_mph", "grade_dec"],
+        "target_names": ["gallons_fastsim"],
+        "powertrain_type": powertrain,
+        "vehicle_description": f"{year} {make} {model}",
+        "path": f"{BASE}/{make}/{model}/{year}/{config_slug}/v{version}",
+        "fuel_type": fuel_type,
+    }
+
+
+def _build_registry(entries: list[dict]) -> S3Registry:
+    """Create an S3Registry pre-loaded with an index containing the given entries."""
+    index = {"schema_version": SCHEMA, "models": entries}
+    objects = {f"{BASE}/index.json": json.dumps(index).encode()}
     registry = S3Registry(
         bucket="test-bucket",
         schema_version=SCHEMA,
         root_prefix=ROOT,
     )
-    registry._client = _MockClient(pages_by_prefix, objects)
+    registry._client = _MockClient(objects)  # type: ignore[assignment]
     return registry
 
 
-class TestListChildren(TestCase):
-    def test_basic(self):
-        prefix = f"{BASE}/"
-        pages = {
-            prefix: [_common_prefixes("toyota", "ford", "chevrolet", prefix=prefix)]
-        }
-        registry = _build_registry(pages)
-
-        children = registry._list_children(prefix)
-        self.assertEqual(sorted(children), ["chevrolet", "ford", "toyota"])
-
-    def test_empty(self):
-        prefix = f"{BASE}/"
-        pages = {prefix: [{"CommonPrefixes": []}]}
-        registry = _build_registry(pages)
-        self.assertEqual(registry._list_children(prefix), [])
-
-    def test_pagination(self):
-        prefix = f"{BASE}/"
-        pages = {
-            prefix: [
-                _common_prefixes("toyota", "ford", prefix=prefix),
-                _common_prefixes("chevrolet", prefix=prefix),
-            ]
-        }
-        registry = _build_registry(pages)
-        children = registry._list_children(prefix)
-        self.assertEqual(sorted(children), ["chevrolet", "ford", "toyota"])
-
-
-class TestNarrowPrefixes(TestCase):
-    def _make_registry_with_makes(self, makes):
-        base_prefix = f"{BASE}/"
-        pages = {base_prefix: [_common_prefixes(*makes, prefix=base_prefix)]}
-        return _build_registry(pages)
-
-    def test_no_filter_expands_all(self):
-        registry = self._make_registry_with_makes(["toyota", "ford", "chevrolet"])
-        result = registry._narrow_prefixes([f"{BASE}/"], None, fuzzy=True, threshold=80)
-        self.assertEqual(len(result), 3)
-        self.assertTrue(all(r.endswith("/") for r in result))
-
-    def test_exact_filter(self):
-        registry = self._make_registry_with_makes(["toyota", "ford", "chevrolet"])
-        result = registry._narrow_prefixes(
-            [f"{BASE}/"], "toyota", fuzzy=False, threshold=80
-        )
-        self.assertEqual(result, [f"{BASE}/toyota/"])
-
-    def test_fuzzy_filter(self):
-        registry = self._make_registry_with_makes(["toyota", "ford", "chevrolet"])
-        result = registry._narrow_prefixes(
-            [f"{BASE}/"], "toyta", fuzzy=True, threshold=80
-        )
-        self.assertEqual(result, [f"{BASE}/toyota/"])
-
-    def test_no_match(self):
-        registry = self._make_registry_with_makes(["toyota", "ford", "chevrolet"])
-        result = registry._narrow_prefixes(
-            [f"{BASE}/"], "zzzzz", fuzzy=True, threshold=80
-        )
-        self.assertEqual(result, [])
-
-    def test_year_filtering(self):
-        """Year level should use year_contains instead of string matching."""
-        year_prefix = f"{BASE}/toyota/camry/"
-        pages = {
-            year_prefix: [
-                _common_prefixes("2016", "2020", "2020-2026", prefix=year_prefix)
-            ]
-        }
-        registry = _build_registry(pages)
-
-        # Query year=2016 should match only "2016"
-        result = registry._narrow_prefixes(
-            [year_prefix],
-            None,
-            fuzzy=True,
-            threshold=80,
-            is_year=True,
-            year_query=2016,
-        )
-        self.assertEqual(result, [f"{year_prefix}2016/"])
-
-        # Query year=2023 should match "2020-2026" range
-        result = registry._narrow_prefixes(
-            [year_prefix],
-            None,
-            fuzzy=True,
-            threshold=80,
-            is_year=True,
-            year_query=2023,
-        )
-        self.assertEqual(result, [f"{year_prefix}2020-2026/"])
-
-    def test_multiple_input_prefixes(self):
-        """Handles multiple parent prefixes (e.g. fuzzy matched multiple makes)."""
-        toyota_prefix = f"{BASE}/toyota/"
-        ford_prefix = f"{BASE}/ford/"
-        pages = {
-            toyota_prefix: [_common_prefixes("camry", "corolla", prefix=toyota_prefix)],
-            ford_prefix: [_common_prefixes("escape", "focus", prefix=ford_prefix)],
-        }
-        registry = _build_registry(pages)
-
-        result = registry._narrow_prefixes(
-            [toyota_prefix, ford_prefix], None, fuzzy=True, threshold=80
-        )
-        self.assertEqual(len(result), 4)
-
-    def test_case_insensitive(self):
-        """Matching should be case-insensitive."""
-        registry = self._make_registry_with_makes(["toyota", "ford"])
-        result = registry._narrow_prefixes(
-            [f"{BASE}/"], "Toyota", fuzzy=False, threshold=80
-        )
-        self.assertEqual(result, [f"{BASE}/toyota/"])
-
-
-class TestQueryHierarchical(TestCase):
-    """End-to-end tests for the rewritten query() with mocked S3."""
-
-    def _build_full_registry(self):
-        """Build a registry with two models:
-        - toyota/camry/2016/rf_default/v1
-        - chevrolet/bolt_ev/2020/rf_transient/v1
-        """
-        toyota_meta = _fake_metadata("toyota", "camry", 2016)
-        chevy_meta = _fake_metadata("chevrolet", "bolt_ev", 2020)
-
-        toyota_dir = f"{BASE}/toyota/camry/2016/rf_default/v1"
-        chevy_dir = f"{BASE}/chevrolet/bolt_ev/2020/rf_transient/v1"
-
-        pages = {
-            # Level 0: makes
-            f"{BASE}/": [_common_prefixes("toyota", "chevrolet", prefix=f"{BASE}/")],
-            # Level 1: models under each make
-            f"{BASE}/toyota/": [_common_prefixes("camry", prefix=f"{BASE}/toyota/")],
-            f"{BASE}/chevrolet/": [
-                _common_prefixes("bolt_ev", prefix=f"{BASE}/chevrolet/")
-            ],
-            # Level 2: years
-            f"{BASE}/toyota/camry/": [
-                _common_prefixes("2016", prefix=f"{BASE}/toyota/camry/")
-            ],
-            f"{BASE}/chevrolet/bolt_ev/": [
-                _common_prefixes("2020", prefix=f"{BASE}/chevrolet/bolt_ev/")
-            ],
-            # Level 3: config slugs
-            f"{BASE}/toyota/camry/2016/": [
-                _common_prefixes("rf_default", prefix=f"{BASE}/toyota/camry/2016/")
-            ],
-            f"{BASE}/chevrolet/bolt_ev/2020/": [
-                _common_prefixes(
-                    "rf_transient", prefix=f"{BASE}/chevrolet/bolt_ev/2020/"
-                )
-            ],
-            # Level 4: versions
-            f"{BASE}/toyota/camry/2016/rf_default/": [
-                _common_prefixes("v1", prefix=f"{BASE}/toyota/camry/2016/rf_default/")
-            ],
-            f"{BASE}/chevrolet/bolt_ev/2020/rf_transient/": [
-                _common_prefixes(
-                    "v1",
-                    prefix=f"{BASE}/chevrolet/bolt_ev/2020/rf_transient/",
-                )
-            ],
-        }
-
-        objects = {
-            f"{toyota_dir}/metadata.json": json.dumps(toyota_meta).encode(),
-            f"{chevy_dir}/metadata.json": json.dumps(chevy_meta).encode(),
-        }
-
-        return _build_registry(pages, objects)
+class TestQueryViaIndex(TestCase):
+    """End-to-end tests for query() served entirely from index.json."""
 
     def test_query_by_make(self):
-        registry = self._build_full_registry()
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
         results = registry.query(make="toyota")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].model_id.make, "toyota")
 
     def test_query_by_make_and_model(self):
-        registry = self._build_full_registry()
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
         results = registry.query(make="chevrolet", model="bolt_ev")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].model_id.model, "bolt_ev")
 
     def test_query_by_year(self):
-        registry = self._build_full_registry()
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
         results = registry.query(year=2016)
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].model_id.make, "toyota")
 
     def test_query_by_config_slug(self):
-        registry = self._build_full_registry()
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
         results = registry.query(config_slug="rf_transient")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].model_id.make, "chevrolet")
 
     def test_query_by_feature_names(self):
-        registry = self._build_full_registry()
-        # both fake models have speed_mph+grade_dec in their feature set
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
         results = registry.query(feature_names=["speed_mph"])
         self.assertEqual(len(results), 2)
         results = registry.query(feature_names=["speed_mph", "nonexistent"])
         self.assertEqual(len(results), 0)
 
     def test_query_fuzzy_make(self):
-        registry = self._build_full_registry()
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
         results = registry.query(make="chevy")
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].model_id.make, "chevrolet")
 
     def test_query_no_match(self):
-        registry = self._build_full_registry()
-        results = registry.query(make="zzzzz")
-        self.assertEqual(len(results), 0)
+        registry = _build_registry(
+            [_index_entry("toyota", "camry", 2016, "rf_default", 1)]
+        )
+        self.assertEqual(registry.query(make="zzzzz"), [])
 
     def test_query_multiple_filters(self):
-        registry = self._build_full_registry()
-        results = registry.query(make="toyota", year=2016)
-        self.assertEqual(len(results), 1)
-        # Wrong year should return empty
-        results = registry.query(make="toyota", year=2020)
-        self.assertEqual(len(results), 0)
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
+        self.assertEqual(len(registry.query(make="toyota", year=2016)), 1)
+        self.assertEqual(len(registry.query(make="toyota", year=2020)), 0)
 
-    def test_query_no_filters_uses_scan(self):
-        """When no filters are provided, falls back to _scan_models."""
-        registry = self._build_full_registry()
-        # Patch _scan_models to verify it's called
-        original_scan = registry._scan_models
-        scan_called = []
-
-        def tracked_scan():
-            scan_called.append(True)
-            return original_scan()
-
-        registry._scan_models = tracked_scan
-
-        # _scan_models needs _list_metadata_keys which expects
-        # a full listing without Delimiter. Add the needed pages.
-        toyota_dir = f"{BASE}/toyota/camry/2016/rf_default/v1"
-        chevy_dir = f"{BASE}/chevrolet/bolt_ev/2020/rf_transient/v1"
-        toyota_meta = _fake_metadata("toyota", "camry", 2016)
-        chevy_meta = _fake_metadata("chevrolet", "bolt_ev", 2020)
-
-        # Override page data for non-Delimiter listing
-        registry._client._paginator.pages_by_prefix[f"{BASE}/"] = [
-            {
-                "Contents": [
-                    {"Key": f"{toyota_dir}/metadata.json"},
-                    {"Key": f"{chevy_dir}/metadata.json"},
-                ]
-            }
-        ]
-        registry._client._objects[f"{toyota_dir}/metadata.json"] = json.dumps(
-            toyota_meta
-        ).encode()
-        registry._client._objects[f"{chevy_dir}/metadata.json"] = json.dumps(
-            chevy_meta
-        ).encode()
-
-        results = registry.query()
-        self.assertTrue(scan_called)
+    def test_query_no_filters_returns_all(self):
+        registry = _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("chevrolet", "bolt_ev", 2020, "rf_transient", 1),
+            ]
+        )
+        results = registry.query(version_strategy="all")
         self.assertEqual(len(results), 2)
+
+
+class TestVersionStrategy(TestCase):
+    """Version strategy and exact-version filter served from the index."""
+
+    def _versioned_registry(self):
+        return _build_registry(
+            [
+                _index_entry("toyota", "camry", 2016, "rf_default", 1),
+                _index_entry("toyota", "camry", 2016, "rf_default", 2),
+                _index_entry("toyota", "camry", 2016, "rf_default", 3),
+            ]
+        )
+
+    def test_default_strategy_returns_latest_only(self):
+        results = self._versioned_registry().query(make="toyota")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].model_id.version, 3)
+
+    def test_strategy_all_returns_every_version(self):
+        results = self._versioned_registry().query(
+            make="toyota", version_strategy="all"
+        )
+        self.assertEqual(len(results), 3)
+
+    def test_exact_version_filter(self):
+        results = self._versioned_registry().query(make="toyota", version=2)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].model_id.version, 2)
+
+    def test_version_filter_overrides_strategy(self):
+        results = self._versioned_registry().query(
+            make="toyota", version=1, version_strategy="latest"
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].model_id.version, 1)
+
+    def test_list_models_default_latest(self):
+        ids = self._versioned_registry().list_models()
+        self.assertEqual(len(ids), 1)
+        self.assertEqual(ids[0].version, 3)
+
+    def test_list_models_all(self):
+        ids = self._versioned_registry().list_models(version_strategy="all")
+        self.assertEqual(len(ids), 3)
+
+
+class TestIndexRequired(TestCase):
+    """When index.json is missing or unreadable, query/list_models must fail clearly."""
+
+    def _no_index_registry(self) -> S3Registry:
+        registry = S3Registry(
+            bucket="test-bucket",
+            schema_version=SCHEMA,
+            root_prefix=ROOT,
+        )
+        # empty objects map -> get_object raises for everything
+        registry._client = _MockClient(objects={})  # type: ignore[assignment]
+        return registry
+
+    def test_query_raises_when_index_missing(self):
+        with self.assertRaises(IndexMissingError) as ctx:
+            self._no_index_registry().query(make="toyota")
+        self.assertIn("build_index", str(ctx.exception))
+
+    def test_list_models_raises_when_index_missing(self):
+        with self.assertRaises(IndexMissingError):
+            self._no_index_registry().list_models()
+
+    def test_query_raises_when_index_unparseable(self):
+        registry = S3Registry(
+            bucket="test-bucket",
+            schema_version=SCHEMA,
+            root_prefix=ROOT,
+        )
+        registry._client = _MockClient(  # type: ignore[assignment]
+            objects={f"{BASE}/index.json": b"not valid json"}
+        )
+        with self.assertRaises(IndexMissingError):
+            registry.query()


### PR DESCRIPTION
Add a version strategy to decide how to handle multiple versions of the same model. Defaults to "latest" where we just pull the latest version. Also allows a specific version (like "v3") to be passed which pull that version. Or, allows "all" to be passed to return all the versions for a model.

Also allows the model id to be passed into load_model without the version string. If that happens, we just assume the latest version should be pulled. This should be a bit cleaner:

```python
model = pt.load_model(
    "toyota/vios_1.5_g/2024/rf_default_859bc692/"
)
```