### PR TITLE
Documentation Fixes

### DIFF
--- a/docs/build_the_docs.md
+++ b/docs/build_the_docs.md
@@ -12,4 +12,4 @@ Then, to build the docs, run the following command from the root of the reposito
 jupyter-book build docs/
 ```
 
-This, build build the docs as html and place them in `docs/_build/html/`. You can then view the docs by opening `docs/_build/html/index.html` in your browser.
+This builds the docs as `.html` and places them in `docs/_build/html/`. You can then view the docs by opening `docs/_build/html/index.html` in your browser.

--- a/docs/build_the_docs.md
+++ b/docs/build_the_docs.md
@@ -1,9 +1,9 @@
 # Build The Docs
 
-The documentation is built using jupyter-book which you can install with pip:
+The documentation is built using jupyter-book V1 which you can install with pip:
 
 ```bash
-pip install jupyter-book
+pip install jupyter-book<2
 ```
 
 Then, to build the docs, run the following command from the root of the repository:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -26,7 +26,7 @@ Each training pipeline has its own set of dependencies.
 
 ### Scikit-learn
 
-To install the depenecies the scikit learn training pipeline, use the following command:
+To install the dependencies for the scikit learn training pipeline, use the following command:
 
 ```bash
 pip install nrel.routee.powertrain[scikit]

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,6 +1,6 @@
 # RouteE Powertrain
 
-RouteE-Powertrain is a Python package that allows users to work with a set of pre-trained mesoscopic vehicle energy prediction models for a varity of vehicle types. Additionally, users can train their own models if "ground truth" energy consumption and driving data are available. RouteE-Powertrain models predict vehicle energy consumption over links in a road network, so the features considered for prediction often include traffic speeds, road grade, turns, etc.
+RouteE-Powertrain is a Python package that allows users to work with a set of pre-trained mesoscopic vehicle energy prediction models for a variety of vehicle types. Additionally, users can train their own models if "ground truth" energy consumption and driving data are available. RouteE-Powertrain models predict vehicle energy consumption over links in a road network, so the features considered for prediction often include traffic speeds, road grade, turns, etc.
 
 ## Quickstart
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -60,9 +60,9 @@ print(model)
 # Predict energy consumption for a set of road links
 links_df = pd.DataFrame(
     {
-        "miles": [0.1, 0.2, 0.3], # miles
+        "distance": [0.1, 0.2, 0.3], # miles
         "speed_mph": [30, 40, 50], # mph
-        "grade_dec": [-0.05, 0, 0.05], # decimal
+        "grade_percent": [-0.5, 0, 0.5], # percent
     }
 )
 

--- a/docs/model_training-ngboost.ipynb
+++ b/docs/model_training-ngboost.ipynb
@@ -24,12 +24,10 @@
    "outputs": [],
    "source": [
     "import nrel.routee.powertrain as pt\n",
-    "\n",
     "from nrel.routee.powertrain.trainers.ngboost_trainer import NGBoostTrainer\n",
     "\n",
     "\n",
-    "import pandas as pd\n",
-    "\n"
+    "import pandas as pd"
    ]
   },
   {
@@ -46,7 +44,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "df = pd.read_csv(\"../tests/routee-powertrain-test-data/sample_train_data.csv\")"
    ]
   },
@@ -151,7 +148,7 @@
    "source": [
     "# Load the data\n",
     "df = pd.read_csv(\"../tests/routee-powertrain-test-data/sample_train_data.csv\")\n",
-    "df.rename(columns={'gallons_fastsim': 'gge'}, inplace=True)\n",
+    "df.rename(columns={\"gallons_fastsim\": \"gge\"}, inplace=True)\n",
     "df = df.dropna()\n",
     "df.head()"
    ]
@@ -176,18 +173,14 @@
     "feature_set_1 = [pt.DataColumn(name=\"speed_mph\", units=\"mph\")]\n",
     "feature_set_2 = [\n",
     "    pt.DataColumn(name=\"speed_mph\", units=\"mph\"),\n",
-    "    pt.DataColumn(name=\"grade_dec\", units=\"decimal\")\n",
+    "    pt.DataColumn(name=\"grade_dec\", units=\"decimal\"),\n",
     "]\n",
     "feature_set_3 = [\n",
     "    pt.DataColumn(name=\"speed_mph\", units=\"mph\"),\n",
     "    pt.DataColumn(name=\"grade_dec\", units=\"decimal\"),\n",
-    "    pt.DataColumn(name=\"road_class\", units=\"category\")\n",
+    "    pt.DataColumn(name=\"road_class\", units=\"category\"),\n",
     "]\n",
-    "features = [\n",
-    "    feature_set_1,\n",
-    "    feature_set_2,\n",
-    "    feature_set_3\n",
-    "]"
+    "features = [feature_set_1, feature_set_2, feature_set_3]"
    ]
   },
   {
@@ -220,8 +213,8 @@
    "outputs": [],
    "source": [
     "energy_target = pt.DataColumn(\n",
-    "    name=\"gge\", \n",
-    "    units=\"gallons_gasoline\", \n",
+    "    name=\"gge\",\n",
+    "    units=\"gallons_gasoline\",\n",
     ")"
    ]
   },
@@ -268,7 +261,7 @@
     "    distance=distance,\n",
     "    target=energy_target,\n",
     "    test_size=0.2,\n",
-    "    predict_method=predict_method\n",
+    "    predict_method=predict_method,\n",
     ")"
    ]
   },
@@ -341,7 +334,7 @@
     {
      "data": {
       "text/html": [
-       "<table border=\"1\" style=\"border-collapse: collapse;\"><tr><td colspan='2' style='border-bottom: 2px solid black;text-align: center;'><b>Estimator Errors</b></td></tr><tr><td>Feature Set ID</td><td>speed_mph</td></tr><tr><td>Target</td><td>gge</td></tr><tr><td>Link RMSE</td><td>0.00147</td></tr><tr><td>Link Norm RMSE</td><td>0.92759</td></tr><tr><td>Link Weighted RPD</td><td>0.76701</td></tr><tr><td>Net Error</td><td>-0.29279</td></tr><tr><td>Actual Dist/Energy</td><td>18.87243</td></tr><tr><td>Predicted Dist/Energy</td><td>26.68559</td></tr><tr><td>Real World Predicted Dist/Energy</td><td>22.88644</td></tr><tr><td>Trip RPD</td><td>0.34300</td></tr><tr><td>Trip Weighted RPD</td><td>0.34300</td></tr><tr><td>Trip RMSE</td><td>0.01204</td></tr><tr><td>Trip Norm RMSE</td><td>0.29279</td></tr><tr><td>Link NLL</td><td>35.87225</td></tr><tr><td>Link CRPS</td><td>0.00074</td></tr><tr><td>Link PICP</td><td>0.77000</td></tr><tr><td colspan='2' style='border-bottom: 2px solid black;text-align: center;'><b>Estimator Errors</b></td></tr><tr><td>Feature Set ID</td><td>grade_dec&speed_mph</td></tr><tr><td>Target</td><td>gge</td></tr><tr><td>Link RMSE</td><td>0.00134</td></tr><tr><td>Link Norm RMSE</td><td>0.84574</td></tr><tr><td>Link Weighted RPD</td><td>0.66150</td></tr><tr><td>Net Error</td><td>-0.22083</td></tr><tr><td>Actual Dist/Energy</td><td>18.87243</td></tr><tr><td>Predicted Dist/Energy</td><td>24.22131</td></tr><tr><td>Real World Predicted Dist/Energy</td><td>20.77299</td></tr><tr><td>Trip RPD</td><td>0.24824</td></tr><tr><td>Trip Weighted RPD</td><td>0.24824</td></tr><tr><td>Trip RMSE</td><td>0.00908</td></tr><tr><td>Trip Norm RMSE</td><td>0.22083</td></tr><tr><td>Link NLL</td><td>28.80077</td></tr><tr><td>Link CRPS</td><td>0.00067</td></tr><tr><td>Link PICP</td><td>0.77000</td></tr><tr><td colspan='2' style='border-bottom: 2px solid black;text-align: center;'><b>Estimator Errors</b></td></tr><tr><td>Feature Set ID</td><td>grade_dec&road_class&speed_mph</td></tr><tr><td>Target</td><td>gge</td></tr><tr><td>Link RMSE</td><td>0.00134</td></tr><tr><td>Link Norm RMSE</td><td>0.84576</td></tr><tr><td>Link Weighted RPD</td><td>0.66152</td></tr><tr><td>Net Error</td><td>-0.22085</td></tr><tr><td>Actual Dist/Energy</td><td>18.87243</td></tr><tr><td>Predicted Dist/Energy</td><td>24.22193</td></tr><tr><td>Real World Predicted Dist/Energy</td><td>20.77352</td></tr><tr><td>Trip RPD</td><td>0.24827</td></tr><tr><td>Trip Weighted RPD</td><td>0.24827</td></tr><tr><td>Trip RMSE</td><td>0.00908</td></tr><tr><td>Trip Norm RMSE</td><td>0.22085</td></tr><tr><td>Link NLL</td><td>29.10197</td></tr><tr><td>Link CRPS</td><td>0.00067</td></tr><tr><td>Link PICP</td><td>0.77000</td></tr></table>"
+       "<table border=\"1\" style=\"border-collapse: collapse;\"><tr><td colspan='2' style='border-bottom: 2px solid black;text-align: center;'><b>Estimator Errors</b></td></tr><tr><td>Feature Set ID</td><td>speed_mph</td></tr><tr><td>Target</td><td>gge</td></tr><tr><td>Link RMSE</td><td>0.00147</td></tr><tr><td>Link Norm RMSE</td><td>0.92759</td></tr><tr><td>Link Weighted RPD</td><td>0.76701</td></tr><tr><td>Net Error</td><td>-0.29279</td></tr><tr><td>Actual Dist/Energy</td><td>18.87243</td></tr><tr><td>Predicted Dist/Energy</td><td>26.68559</td></tr><tr><td>Real World Predicted Dist/Energy</td><td>22.88644</td></tr><tr><td>Trip RPD</td><td>0.34300</td></tr><tr><td>Trip Weighted RPD</td><td>0.34300</td></tr><tr><td>Trip RMSE</td><td>0.01204</td></tr><tr><td>Trip Norm RMSE</td><td>0.29279</td></tr><tr><td>Link NLL</td><td>35.87225</td></tr><tr><td>Link CRPS</td><td>0.00074</td></tr><tr><td>Link PICP</td><td>0.77000</td></tr><tr><td>Trip NLL</td><td>-2.08881</td></tr><tr><td>Trip CRPS</td><td>0.00884</td></tr><tr><td>Trip PICP</td><td>0.00000</td></tr><tr><td colspan='2' style='border-bottom: 2px solid black;text-align: center;'><b>Estimator Errors</b></td></tr><tr><td>Feature Set ID</td><td>grade_dec&speed_mph</td></tr><tr><td>Target</td><td>gge</td></tr><tr><td>Link RMSE</td><td>0.00134</td></tr><tr><td>Link Norm RMSE</td><td>0.84574</td></tr><tr><td>Link Weighted RPD</td><td>0.66150</td></tr><tr><td>Net Error</td><td>-0.22083</td></tr><tr><td>Actual Dist/Energy</td><td>18.87243</td></tr><tr><td>Predicted Dist/Energy</td><td>24.22131</td></tr><tr><td>Real World Predicted Dist/Energy</td><td>20.77299</td></tr><tr><td>Trip RPD</td><td>0.24824</td></tr><tr><td>Trip Weighted RPD</td><td>0.24824</td></tr><tr><td>Trip RMSE</td><td>0.00908</td></tr><tr><td>Trip Norm RMSE</td><td>0.22083</td></tr><tr><td>Link NLL</td><td>28.80077</td></tr><tr><td>Link CRPS</td><td>0.00067</td></tr><tr><td>Link PICP</td><td>0.77000</td></tr><tr><td>Trip NLL</td><td>-3.05846</td></tr><tr><td>Trip CRPS</td><td>0.00603</td></tr><tr><td>Trip PICP</td><td>1.00000</td></tr><tr><td colspan='2' style='border-bottom: 2px solid black;text-align: center;'><b>Estimator Errors</b></td></tr><tr><td>Feature Set ID</td><td>grade_dec&road_class&speed_mph</td></tr><tr><td>Target</td><td>gge</td></tr><tr><td>Link RMSE</td><td>0.00134</td></tr><tr><td>Link Norm RMSE</td><td>0.84576</td></tr><tr><td>Link Weighted RPD</td><td>0.66152</td></tr><tr><td>Net Error</td><td>-0.22085</td></tr><tr><td>Actual Dist/Energy</td><td>18.87243</td></tr><tr><td>Predicted Dist/Energy</td><td>24.22193</td></tr><tr><td>Real World Predicted Dist/Energy</td><td>20.77352</td></tr><tr><td>Trip RPD</td><td>0.24827</td></tr><tr><td>Trip Weighted RPD</td><td>0.24827</td></tr><tr><td>Trip RMSE</td><td>0.00908</td></tr><tr><td>Trip Norm RMSE</td><td>0.22085</td></tr><tr><td>Link NLL</td><td>29.10197</td></tr><tr><td>Link CRPS</td><td>0.00067</td></tr><tr><td>Link PICP</td><td>0.77000</td></tr><tr><td>Trip NLL</td><td>-3.05223</td></tr><tr><td>Trip CRPS</td><td>0.00604</td></tr><tr><td>Trip PICP</td><td>1.00000</td></tr></table>"
       ],
       "text/plain": [
        "====================================================\n",
@@ -361,6 +354,9 @@
        "Link NLL                         35.872\n",
        "Link CRPS                        0.001\n",
        "Link PICP                        0.770\n",
+       "Trip NLL                         -2.089\n",
+       "Trip CRPS                        0.009\n",
+       "Trip PICP                        0.000\n",
        "====================================================\n",
        "Feature Set ID:                  grade_dec&speed_mph\n",
        "Target:                          gge\n",
@@ -378,6 +374,9 @@
        "Link NLL                         28.801\n",
        "Link CRPS                        0.001\n",
        "Link PICP                        0.770\n",
+       "Trip NLL                         -3.058\n",
+       "Trip CRPS                        0.006\n",
+       "Trip PICP                        1.000\n",
        "====================================================\n",
        "Feature Set ID:                  grade_dec&road_class&speed_mph\n",
        "Target:                          gge\n",
@@ -395,6 +394,9 @@
        "Link NLL                         29.102\n",
        "Link CRPS                        0.001\n",
        "Link PICP                        0.770\n",
+       "Trip NLL                         -3.052\n",
+       "Trip CRPS                        0.006\n",
+       "Trip PICP                        1.000\n",
        "===================================================="
       ]
      },
@@ -404,7 +406,7 @@
     }
    ],
    "source": [
-    "test_vehicle.errors\n"
+    "test_vehicle.errors"
    ]
   },
   {
@@ -489,7 +491,7 @@
     }
    ],
    "source": [
-    "result_df = test_vehicle.predict(df, ['grade_dec', 'speed_mph','road_class'], 'miles', True)\n",
+    "result_df = test_vehicle.predict(df, [\"grade_dec\", \"speed_mph\", \"road_class\"], \"miles\")\n",
     "result_df.head()"
    ]
   },
@@ -529,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,18 +551,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'speed_mph': <nrel.routee.powertrain.estimators.ngboost_estimator.NGBoostEstimator at 0x1597b3910>,\n",
-       " 'grade_dec&speed_mph': <nrel.routee.powertrain.estimators.ngboost_estimator.NGBoostEstimator at 0x159802b90>,\n",
-       " 'grade_dec&road_class&speed_mph': <nrel.routee.powertrain.estimators.ngboost_estimator.NGBoostEstimator at 0x159890850>}"
+       "{'speed_mph': <nrel.routee.powertrain.estimators.ngboost_estimator.NGBoostEstimator at 0x19ca5ae2810>,\n",
+       " 'grade_dec&speed_mph': <nrel.routee.powertrain.estimators.ngboost_estimator.NGBoostEstimator at 0x19ca5a7bfe0>,\n",
+       " 'grade_dec&road_class&speed_mph': <nrel.routee.powertrain.estimators.ngboost_estimator.NGBoostEstimator at 0x19ca5b43fe0>}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -578,11 +580,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_vehicle.estimators['grade_dec&speed_mph'].to_file(\"test_vehicle_speed_grade.bin\")"
+    "test_vehicle.estimators[\"grade_dec&speed_mph\"].to_file(\"test_vehicle_speed_grade.bin\")"
    ]
   },
   {
@@ -591,18 +593,11 @@
    "source": [
     "Now we can load `test_vehicle_speed_grade.bin` into RouteE Comapss"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "dev",
    "language": "python",
    "name": "python3"
   },
@@ -616,7 +611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.12.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/model_training-ngboost.ipynb
+++ b/docs/model_training-ngboost.ipynb
@@ -157,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This dataframe represents a set of road network links (i.e. roads) in which we've already computed the energy consumption over. In this case, we've use the Fastsim software to simulate a vehicle driving over a high resolution drive cycle and then have aggregated everything up to the link level. We also have link level attributes like average driving speed in mile per hour (`speed`), road gradient as a decimal (`grade`), road distance in miles (`miles`) and road classification as a integer category (`road_class`). Lastly, we have a trip identifier column (`trip_id`) which is only 1 in this case, represeting a single trip taken by this vehicle.\n",
+    "This dataframe represents a set of road network links (i.e. roads) in which we've already computed the energy consumption over. In this case, we've use the FastSIM software to simulate a vehicle driving over a high resolution drive cycle and then have aggregated everything up to the link level. We also have link level attributes like average driving speed in mile per hour (`speed`), road gradient as a decimal (`grade`), road distance in miles (`miles`) and road classification as a integer category (`road_class`). Lastly, we have a trip identifier column (`trip_id`) which is only 1 in this case, representing a single trip taken by this vehicle.\n",
     "\n",
     "Ok, onto setting up the training pipeline.\n",
     "\n",
@@ -187,7 +187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that we didn't incude the distance column in any of our feature sets. That is because, RouteE Powertrain always requires distance information and so we have a special designation for distance in the training configuation whereas features can be any arbitrary link attribute. So, let's define our distance columns"
+    "Note that we didn't include the distance column in any of our feature sets. This is because RouteE Powertrain always requires distance information and so we have a special designation for distance in the training configuration whereas features can be any arbitrary link attribute. So, let's define our distance columns"
    ]
   },
   {
@@ -203,7 +203,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we need to define our energy target which is gallons of gasoline simualted by Fastsim:"
+    "Now, we need to define our energy target which is gallons of gasoline simulated by FastSIM:"
    ]
   },
   {
@@ -222,13 +222,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We also need to decide how we want to predict the energy.\n",
-    "We have two options: \"rate\" or \"raw\".\n",
-    "\"rate\" will take our energy values and divide them by the distance column to arrive at and energy rate.\n",
-    "Then, the estimator will be trained to predict the rate value (without using distance as a feature) and then the model will multiply the rate value by the incoming link distance to give a final raw energy value.\n",
-    "This can be useful in your training data is sparse as it allows the model to be flexible to distance.\n",
-    "\"raw\" will tell the estimator to predict the energy on the link directly, using distance as an explicit feature.\n",
-    "This can be more robust for situations where the energy rate on a link might vary with respect to distance but can lead to weird results if there are not a good representation of different distance values in the training dataset.\n",
+    "We also need to decide how we want to predict the energy. We have two options: \"rate\" or \"raw\".  \n",
+    "\n",
+    "\"rate\" will take our energy values and divide them by the distance column to calculate an energy rate. Then, the estimator will be trained to predict the rate value (without using distance as a feature) and then the model will multiply the rate value by the incoming link distance to give a final raw energy value. This can be useful if your training data is sparse as it allows the model to be flexible to distance.  \n",
+    "\n",
+    "\"raw\" will tell the estimator to predict the energy on the link directly, using distance as an explicit feature. This can be more robust in situations where the energy rate on a link might vary with respect to distance but can lead to weird results if there are not good representations of different distance values in the training dataset.  \n",
+    "\n",
     "In our case we'll use \"rate\" since our training data is very sparse."
    ]
   },
@@ -499,7 +498,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While this training dataset is far too small to draw real conclusions, these metrics can give you an idea of how well the model performed on a holdout test set (20% of the training data as we specificed by the `test_size` parameter in the configuration. "
+    "While this training dataset is far too small to draw real conclusions, these metrics can give you an idea of how well the model performed on a holdout test set (20% of the training data as we specified by the `test_size` parameter in the configuration). "
    ]
   },
   {

--- a/docs/model_training-smartcore.ipynb
+++ b/docs/model_training-smartcore.ipynb
@@ -167,7 +167,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This dataframe represents a set of road network links (i.e. roads) in which we've already computed the energy consumption over. In this case, we've use the Fastsim software to simulate a vehicle driving over a high resolution drive cycle and then have aggregated everything up to the link level. We also have link level attributes like average driving speed in mile per hour (`speed`), road gradient as a decimal (`grade`), road distance in miles (`miles`) and road classification as a integer category (`road_class`). Lastly, we have a trip identifier column (`trip_id`) which is only 1 in this case, represeting a single trip taken by this vehicle.\n",
+    "This dataframe represents a set of road network links (i.e. roads) in which we've already computed the energy consumption over. In this case, we've use the FastSIM software to simulate a vehicle driving over a high resolution drive cycle and then have aggregated everything up to the link level. We also have link level attributes like average driving speed in mile per hour (`speed`), road gradient as a decimal (`grade`), road distance in miles (`miles`) and road classification as a integer category (`road_class`). Lastly, we have a trip identifier column (`trip_id`) which is only 1 in this case, representing a single trip taken by this vehicle.\n",
     "\n",
     "Ok, onto setting up the training pipeline.\n",
     "\n",
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that we didn't incude the distance column in any of our feature sets. That is because, RouteE Powertrain always requires distance information and so we have a special designation for distance in the training configuation whereas features can be any arbitrary link attribute. So, let's define our distance columns"
+    "Note that we didn't include the distance column in any of our feature sets. This is because RouteE Powertrain always requires distance information and so we have a special designation for distance in the training configuration whereas features can be any arbitrary link attribute. So, let's define our distance columns"
    ]
   },
   {
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we need to define our energy target which is gallons of gasoline simualted by Fastsim:"
+    "Now, we need to define our energy target which is gallons of gasoline simulated by FastSIM:"
    ]
   },
   {
@@ -236,13 +236,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We also need to decide how we want to predict the energy.\n",
-    "We have two options: \"rate\" or \"raw\".\n",
-    "\"rate\" will take our energy values and divide them by the distance column to arrive at and energy rate.\n",
-    "Then, the estimator will be trained to predict the rate value (without using distance as a feature) and then the model will multiply the rate value by the incoming link distance to give a final raw energy value.\n",
-    "This can be useful in your training data is sparse as it allows the model to be flexible to distance.\n",
-    "\"raw\" will tell the estimator to predict the energy on the link directly, using distance as an explicit feature.\n",
-    "This can be more robust for situations where the energy rate on a link might vary with respect to distance but can lead to weird results if there are not a good representation of different distance values in the training dataset.\n",
+    "We also need to decide how we want to predict the energy. We have two options: \"rate\" or \"raw\".  \n",
+    "\n",
+    "\"rate\" will take our energy values and divide them by the distance column to calculate an energy rate. Then, the estimator will be trained to predict the rate value (without using distance as a feature) and then the model will multiply the rate value by the incoming link distance to give a final raw energy value. This can be useful if your training data is sparse as it allows the model to be flexible to distance.  \n",
+    "\n",
+    "\"raw\" will tell the estimator to predict the energy on the link directly, using distance as an explicit feature. This can be more robust in situations where the energy rate on a link might vary with respect to distance but can lead to weird results if there are not good representations of different distance values in the training dataset.  \n",
+    "\n",
     "In our case we'll use \"rate\" since our training data is very sparse."
    ]
   },
@@ -387,7 +386,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While this training dataset is far too small to draw real conclusions, these metrics can give you an idea of how well the model performed on a holdout test set (20% of the training data as we specificed by the `test_size` parameter in the configuration. "
+    "While this training dataset is far too small to draw real conclusions, these metrics can give you an idea of how well the model performed on a holdout test set (20% of the training data as we specified by the `test_size` parameter in the configuration). "
    ]
   },
   {
@@ -465,13 +464,6 @@
    "source": [
     "Now we can load `test_vehicle_speed_grade.bin` into RouteE Comapss"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/docs/model_training.ipynb
+++ b/docs/model_training.ipynb
@@ -25,7 +25,9 @@
    "source": [
     "import nrel.routee.powertrain as pt\n",
     "\n",
-    "from nrel.routee.powertrain.trainers.sklearn_random_forest import SklearnRandomForestTrainer"
+    "from nrel.routee.powertrain.trainers.sklearn_random_forest import (\n",
+    "    SklearnRandomForestTrainer,\n",
+    ")"
    ]
   },
   {
@@ -153,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This dataframe represents a set of road network links (i.e. roads) in which we've already computed the energy consumption over. In this case, we've use the Fastsim software to simulate a vehicle driving over a high resolution drive cycle and then have aggregated everything up to the link level. We also have link level attributes like average driving speed in mile per hour (`speed`), road gradient as a decimal (`grade`), road distance in miles (`miles`) and road classification as a integer category (`road_class`). Lastly, we have a trip identifier column (`trip_id`) which is only 1 in this case, represeting a single trip taken by this vehicle.\n",
+    "This dataframe represents a set of road network links (i.e. roads) in which we've already computed the energy consumption over. In this case, we've used the FastSIM software to simulate a vehicle driving over a high resolution drive cycle and then have aggregated everything up to the link level. We also have link level attributes like average driving speed in mile per hour (`speed`), road gradient as a decimal (`grade`), road distance in miles (`miles`) and road classification as a integer category (`road_class`). Lastly, we have a trip identifier column (`trip_id`) which is only 1 in this case, representing a single trip taken by this vehicle.\n",
     "\n",
     "Ok, onto setting up the training pipeline.\n",
     "\n",
@@ -169,25 +171,21 @@
     "feature_set_1 = [pt.DataColumn(name=\"speed_mph\", units=\"mph\")]\n",
     "feature_set_2 = [\n",
     "    pt.DataColumn(name=\"speed_mph\", units=\"mph\"),\n",
-    "    pt.DataColumn(name=\"grade_dec\", units=\"decimal\")\n",
+    "    pt.DataColumn(name=\"grade_dec\", units=\"decimal\"),\n",
     "]\n",
     "feature_set_3 = [\n",
     "    pt.DataColumn(name=\"speed_mph\", units=\"mph\"),\n",
     "    pt.DataColumn(name=\"grade_dec\", units=\"decimal\"),\n",
-    "    pt.DataColumn(name=\"road_class\", units=\"category\")\n",
+    "    pt.DataColumn(name=\"road_class\", units=\"category\"),\n",
     "]\n",
-    "features = [\n",
-    "    feature_set_1,\n",
-    "    feature_set_2,\n",
-    "    feature_set_3\n",
-    "]"
+    "features = [feature_set_1, feature_set_2, feature_set_3]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that we didn't incude the distance column in any of our feature sets. That is because, RouteE Powertrain always requires distance information and so we have a special designation for distance in the training configuation whereas features can be any arbitrary link attribute. So, let's define our distance columns"
+    "Note that we didn't include the distance column in any of our feature sets. That is because, RouteE Powertrain always requires distance information and so we have a special designation for distance in the training configuration whereas features can be any arbitrary link attribute. So, let's define our distance columns"
    ]
   },
   {
@@ -203,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we need to define our energy target which is gallons of gasoline simualted by Fastsim:"
+    "Now, we need to define our energy target which is gallons of gasoline simulated by FastSIM:"
    ]
   },
   {
@@ -213,8 +211,8 @@
    "outputs": [],
    "source": [
     "energy_target = pt.DataColumn(\n",
-    "    name=\"gallons_fastsim\", \n",
-    "    units=\"gallons_gasoline\", \n",
+    "    name=\"gallons_fastsim\",\n",
+    "    units=\"gallons_gasoline\",\n",
     ")"
    ]
   },
@@ -222,13 +220,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We also need to decide how we want to predict the energy.\n",
-    "We have two options: \"rate\" or \"raw\".\n",
-    "\"rate\" will take our energy values and divide them by the distance column to arrive at and energy rate.\n",
-    "Then, the estimator will be trained to predict the rate value (without using distance as a feature) and then the model will multiply the rate value by the incoming link distance to give a final raw energy value.\n",
-    "This can be useful in your training data is sparse as it allows the model to be flexible to distance.\n",
-    "\"raw\" will tell the estimator to predict the energy on the link directly, using distance as an explicit feature.\n",
-    "This can be more robust for situations where the energy rate on a link might vary with respect to distance but can lead to weird results if there are not a good representation of different distance values in the training dataset.\n",
+    "We also need to decide how we want to predict the energy. We have two options: \"rate\" or \"raw\".  \n",
+    "\n",
+    "\"rate\" will take our energy values and divide them by the distance column to calculate an energy rate. Then, the estimator will be trained to predict the rate value (without using distance as a feature) and then the model will multiply the rate value by the incoming link distance to give a final raw energy value. This can be useful if your training data is sparse as it allows the model to be flexible to distance.  \n",
+    "\n",
+    "\"raw\" will tell the estimator to predict the energy on the link directly, using distance as an explicit feature. This can be more robust in situations where the energy rate on a link might vary with respect to distance but can lead to weird results if there are not good representations of different distance values in the training dataset.  \n",
+    "\n",
     "In our case we'll use \"rate\" since our training data is very sparse."
    ]
   },
@@ -261,7 +258,7 @@
     "    distance=distance,\n",
     "    target=energy_target,\n",
     "    test_size=0.2,\n",
-    "    predict_method=predict_method\n",
+    "    predict_method=predict_method,\n",
     ")"
    ]
   },
@@ -279,10 +276,7 @@
    "outputs": [],
    "source": [
     "trainer = SklearnRandomForestTrainer(\n",
-    "    max_depth=10,\n",
-    "    min_samples_split=10,\n",
-    "    n_estimators=20,\n",
-    "    cores=4\n",
+    "    max_depth=10, min_samples_split=10, n_estimators=20, cores=4\n",
     ")"
    ]
   },
@@ -378,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "While this training dataset is far too small to draw real conclusions, these metrics can give you an idea of how well the model performed on a holdout test set (20% of the training data as we specificed by the `test_size` parameter in the configuration. "
+    "While this training dataset is far too small to draw real conclusions, these metrics can give you an idea of how well the model performed on a holdout test set (20% of the training data as we specified by the `test_size` parameter in the configuration). "
    ]
   },
   {
@@ -391,18 +385,11 @@
     "test_vehicle.to_file(\"Test_Vehicle.json\")\n",
     "```"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "dev",
    "language": "python",
    "name": "python3"
   },
@@ -416,7 +403,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-jupyter-book
+jupyter-book<2
 matplotlib
 numpy

--- a/docs/what_is_routee.ipynb
+++ b/docs/what_is_routee.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# What is RouteE?\n",
     "\n",
-    "RouteE-Powertrain is a Python package that allows users to work with a set of pre-trained mesoscopic vehicle energy prediction models for a varity of vehicle types. Additionally, users can train their own models if \"ground truth\" energy consumption and driving data are available. RouteE-Powertrain models predict vehicle energy consumption over links in a road network, so the features considered for prediction often include traffic speeds, road grade, turns, etc. Common applications of RouteE-Powertrain are energy-aware (\"eco\") routing (like [RouteE-Compass](https://nrel.github.io/routee-compass/intro.html)), energy accounting in mesoscopic simulations, and range estimation (especially for EVs). The diagrams below illustrate the logic and data flows for training custom RouteE-Powertrain models and performing prediction with previously trained models.\n",
+    "RouteE-Powertrain is a Python package that allows users to work with a set of pre-trained mesoscopic vehicle energy prediction models for a variety of vehicle types. Additionally, users can train their own models if \"ground truth\" energy consumption and driving data are available. RouteE-Powertrain models predict vehicle energy consumption over links in a road network, so the features considered for prediction often include traffic speeds, road grade, turns, etc. Common applications of RouteE-Powertrain are energy-aware (\"eco\") routing (like [RouteE-Compass](https://nrel.github.io/routee-compass/intro.html)), energy accounting in mesoscopic simulations, and range estimation (especially for EVs). The diagrams below illustrate the logic and data flows for training custom RouteE-Powertrain models and performing prediction with previously trained models.\n",
     "\n",
     "## Training\n",
     "![image](https://github.com/NREL/routee-powertrain/assets/4818940/f5a89f64-241b-494b-9fe6-e13a34595da0)\n",
@@ -117,8 +117,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "camry = pt.load_model('2016_TOYOTA_Camry_4cyl_2WD')\n",
-    "tesla = pt.load_model('2022_Tesla_Model_Y_RWD')"
+    "camry = pt.load_model(\"2016_TOYOTA_Camry_4cyl_2WD\")\n",
+    "tesla = pt.load_model(\"2022_Tesla_Model_Y_RWD\")"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "hatch",
     "shapely",
     "boxsdk",
-    "jupyter-book",
+    "jupyter-book<2",
     "sphinx-book-theme",
     "types-PyYAML",
     "types-protobuf",


### PR DESCRIPTION
## Description
This PR fixes basic issues in the documentation and example notebooks, including clarifying dependency versions and ensuring examples run correctly. 

## Changes

### Pin jupyter-book to <2
- **`requirements.txt` & `pyproject.toml`**: Documentation is built in jupyter-book V1 style and fails to compile with V2. Pin to `jupyter-book<2` to ensure documentation compiles.
- **`build_the_docs.md`**: Clarified that jupyter-book V1 is required.

### Update intro example to mirror README
- **`intro.md`**: Update example python script due to the previous version erroring. This issue was previously noted and fixed in the README by @iantei in issue #29. This update mirrors that fix to this file.

### Fix .predict() call in model_training.ngboost notebook
- **`model_training.ngboost.ipynb`**: Removed extra argument from `.predict()` function call. Cell now runs without error and output matches the previous version of the document.

### Fix typos and grammatical errors
- **`build_the_docs.md`**
- **`installation.md`**
- **`intro.md`**
- **`model_training.ipynb`**
- **`model_training-ngboost.ipynb`**
- **`model_training-smartcore.ipynb`**
- **`what_is_routee.ipynb`**