### PR TITLE
Add helper to write to registry schema

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -19,6 +19,7 @@ parts:
       - file: examples/model_training_example
       - file: examples/temperature_models_example
       - file: examples/to_lookup_table_example
+      - file: publishing_a_model
 
   - caption: Developers
     chapters:

--- a/docs/publishing_a_model.md
+++ b/docs/publishing_a_model.md
@@ -1,0 +1,148 @@
+# Publishing a Trained Model
+
+After training a model with one of the `Trainer` classes, you can save it
+into the v2 registry layout that `LocalRegistry` and `S3Registry` understand.
+This page walks through writing a trained model into a local registry, picking
+a `config_slug`, and loading it back through `pt.load_model()`.
+
+## The v2 Registry Layout
+
+Every model in the registry lives in a five-segment path:
+
+```
+<registry_root>/v2/<make>/<model>/<year>/<config_slug>/v<N>/
+    metadata.json
+    model.onnx        # (or another binary, depending on the estimator)
+```
+
+The bundled example at
+`routee/powertrain/resources/bundled_registry/v2/toyota/camry_4cyl_2wd/2016/rf_default/v1/`
+is a concrete reference for what the on-disk layout looks like.
+
+## Picking a `config_slug`
+
+The `config_slug` disambiguates multiple trained configurations for the same
+vehicle and year. The full feature composition and estimator architecture live
+inside `metadata.json`; the slug is a short human-readable handle.
+
+The informal convention used by existing slugs (`rf_default`, `cnn_5link`,
+`rf_steady_temp`) is:
+
+- **Format**: lowercase snake_case, `<architecture>_<descriptor>`.
+- **Use `_default`** when the model is the canonical configuration for that
+  architecture on that vehicle.
+- **The descriptor encodes the meaningful axis of variation** — feature
+  subset (`rf_steady_temp`), input window (`cnn_5link`), or training-data
+  scope. It is _not_ the date, the trainer's initials, or a version number.
+- **Do not put version info in the slug.** Re-training the same configuration
+  bumps `v<N>` (e.g. `rf_default/v2`). A materially different feature set or
+  architecture should use a _new_ slug and start at `v1`.
+
+## Train and Publish
+
+`Model.save_to_registry()` writes a trained model into the canonical layout in
+one call. It pulls `make`, `model`, and `year` from `model.metadata.config`,
+so make sure those fields on your `ModelConfig` are correct before training.
+
+```python
+import routee.powertrain as pt
+from routee.powertrain.trainers.sklearn_random_forest import (
+    SklearnRandomForestTrainer,
+)
+
+config = pt.ModelConfig(
+    vehicle_description="2024 Test Sedan",
+    powertrain_type=pt.PowertrainType.ICE,
+    feature_set=pt.FeatureSet(features=[
+        pt.DataColumn(name="speed_mph", units="mph"),
+        pt.DataColumn(name="grade_dec", units="decimal"),
+    ]),
+    distance=pt.DataColumn(name="miles", units="miles"),
+    target=pt.TargetSet(targets=[
+        pt.DataColumn(name="gallons_fastsim", units="gallons_gasoline"),
+    ]),
+    make="Test",
+    model="Sedan",
+    year=2024,
+)
+
+model = SklearnRandomForestTrainer().train(training_df, config)
+
+model_id = model.save_to_registry(
+    registry_root="./my_local_registry",
+    config_slug="rf_default",
+    version=1,
+)
+print(model_id)  # test/sedan/2024/rf_default/v1
+```
+
+This creates `./my_local_registry/v2/test/sedan/2024/rf_default/v1/` with
+`metadata.json` and `model.onnx` inside. If the directory already has files,
+the call raises `FileExistsError` — bump `version` or pass `overwrite=True`.
+
+## Load It Back
+
+There are two equivalent ways to load a model from the registry you just
+wrote.
+
+**Option A — explicit `LocalRegistry`:**
+
+```python
+from routee.powertrain.registry.local import LocalRegistry
+
+model = LocalRegistry("./my_local_registry").load(model_id)
+predictions = model.predict(links_df)
+```
+
+**Option B — `pt.load_model()` driven by environment variables:**
+
+```python
+import os
+import routee.powertrain as pt
+
+os.environ["ROUTEE_REGISTRY_BACKEND"] = "local"
+os.environ["ROUTEE_LOCAL_REGISTRY_ROOT"] = "./my_local_registry"
+
+# Omit the trailing v<N> to get the latest version.
+model = pt.load_model("test/sedan/2024/rf_default")
+```
+
+You can also list and query what's in the registry the same way you would
+with the default S3 registry:
+
+```python
+pt.list_available_models()
+pt.query_available_models(make="test", powertrain_type="ICE")
+```
+
+## What's in `metadata.json`
+
+`metadata.json` is written automatically by the save call. Most of its
+contents come from your `ModelConfig` and the trainer:
+
+| Field                                                      | Source                                           |
+| ---------------------------------------------------------- | ------------------------------------------------ |
+| `schema_version`                                           | `routee.powertrain.core.metadata.SCHEMA_VERSION` |
+| `estimator_type`                                           | The trainer (e.g. `"ONNXEstimator"`)             |
+| `architecture_tag`                                         | The trainer (e.g. `"random_forest"`, `"cnn"`)    |
+| `input_spec`                                               | The estimator (lookback / grouping column / pad) |
+| `model_file`                                               | Filename of the binary (e.g. `"model.onnx"`)     |
+| `errors`                                                   | Computed during `Trainer.train()`                |
+| `routee_version`                                           | Package version at save time                     |
+| `config.make / model / year`                               | From `ModelConfig` — drives the path             |
+| `config.powertrain_type`                                   | From `ModelConfig`                               |
+| `config.vehicle_description`                               | From `ModelConfig`                               |
+| `config.feature_set / target / distance`                   | From `ModelConfig`                               |
+| `config.mass_lbs / fuel_type / drivetrain / engine / trim` | From `ModelConfig` (optional)                    |
+
+See `routee/powertrain/core/metadata.py` for the full schema and
+`routee/powertrain/core/model_config.py` for the `ModelConfig` fields.
+
+## Sharing Your Model
+
+Once your model loads cleanly from a local registry, that same directory tree
+is what gets uploaded to the shared S3 bucket. Publishing to the shared
+bucket requires write access and is currently a maintainer step — package the
+`<registry_root>/v2/...` directory (or zip it) and hand it off. The
+maintainer-side upload and index-refresh scripts live at
+`scripts/upload_to_s3.py` and `scripts/build_s3_index.py`.

--- a/docs/what_is_routee.md
+++ b/docs/what_is_routee.md
@@ -43,6 +43,8 @@ Model discovery and retrieval go through a `ModelRegistry` abstraction. By defau
 
 A `ModelId` is structured as `<make>/<model>/<year>/<config_slug>/v<N>`, where `config_slug` (e.g. `rf_default`, `cnn_5link`) disambiguates multiple trained models for the same vehicle/year. For example, we might have 3 difference model architectures for a specific vehicle, or, we might have models trained on different input feature sets. Omit the trailing `v<N>` to load the latest version.
 
+For a step-by-step walkthrough of training a new model and writing it into the registry layout, see [Publishing a Model](publishing_a_model.md).
+
 | Variable                     | Default                           | Meaning                               |
 | ---------------------------- | --------------------------------- | ------------------------------------- |
 | `ROUTEE_REGISTRY_BACKEND`    | `s3`                              | Backend to use: `s3` or `local`       |

--- a/routee/powertrain/__init__.py
+++ b/routee/powertrain/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "query_available_models",
     "load_model",
     "load_sample_route",
+    "save_to_registry",
     "visualize_features",
     "contour_plot",
 ]
@@ -28,6 +29,7 @@ from .core.fuel_type import FuelType
 from .core.model import Model
 from .core.model_config import ModelConfig
 from .core.powertrain_type import PowertrainType
+from .io.archive import save_to_registry
 from .io.load import (
     list_available_models,
     query_available_models,

--- a/routee/powertrain/core/model.py
+++ b/routee/powertrain/core/model.py
@@ -17,6 +17,7 @@ from routee.powertrain.io.archive import (
     save_model_directory,
     save_archive,
     save_tar_archive,
+    save_to_registry as _save_to_registry,
 )
 from routee.powertrain.io.to_lookup_table import to_lookup_table
 from routee.powertrain.validation.feature_visualization import (
@@ -87,6 +88,33 @@ class Model:
         else:
             # No extension → flat directory
             save_model_directory(self, path)
+
+    def save_to_registry(
+        self,
+        registry_root: Union[str, Path],
+        config_slug: str,
+        version: int = 1,
+        schema_version: str = "v2",
+        overwrite: bool = False,
+    ):
+        """
+        Save this model into a local registry directory tree.
+
+        Builds the canonical ``<registry_root>/<schema_version>/<make>/<model>/<year>/<config_slug>/v<N>/``
+        layout from ``self.metadata.config`` plus the caller-supplied
+        ``config_slug`` and ``version``. See
+        ``routee.powertrain.io.archive.save_to_registry`` for full details.
+
+        Returns: the ``ModelId`` that was written.
+        """
+        return _save_to_registry(
+            self,
+            registry_root=registry_root,
+            config_slug=config_slug,
+            version=version,
+            schema_version=schema_version,
+            overwrite=overwrite,
+        )
 
     def to_lookup_table(
         self,

--- a/routee/powertrain/io/archive.py
+++ b/routee/powertrain/io/archive.py
@@ -11,6 +11,7 @@ from routee.powertrain.core.metadata import Metadata, SCHEMA_VERSION
 
 if TYPE_CHECKING:
     from routee.powertrain.core.model import Model
+    from routee.powertrain.registry.model_id import ModelId
 
 METADATA_FILENAME = "metadata.json"
 
@@ -80,6 +81,79 @@ def save_model_directory(model: Model, path: Union[str, Path]) -> None:
 
     (path / METADATA_FILENAME).write_text(json.dumps(metadata_dict, indent=2))
     (path / model_filename).write_bytes(model.estimator.to_bytes())
+
+
+def save_to_registry(
+    model: Model,
+    registry_root: Union[str, Path],
+    config_slug: str,
+    version: int = 1,
+    schema_version: str = "v2",
+    overwrite: bool = False,
+) -> ModelId:
+    """
+    Save a model into a local registry directory tree.
+
+    Builds the canonical path
+    ``<registry_root>/<schema_version>/<make>/<model>/<year>/<config_slug>/v<N>/``
+    using ``make``/``model``/``year`` from ``model.metadata.config`` plus the
+    caller-supplied ``config_slug`` and ``version``. The resulting directory
+    is directly loadable by ``LocalRegistry`` — or by ``pt.load_model(...)``
+    when ``ROUTEE_REGISTRY_BACKEND=local`` and ``ROUTEE_LOCAL_REGISTRY_ROOT``
+    points at ``registry_root``.
+
+    Args:
+        model: the trained model to save
+        registry_root: filesystem root of the local registry (the directory
+            that contains the ``<schema_version>/`` subtree)
+        config_slug: identifier disambiguating multiple trained configurations
+            for the same vehicle/year (e.g. ``rf_default``, ``cnn_5link``).
+            Lowercase snake_case is conventional.
+        version: positive integer version. Bump when retraining the same
+            ``config_slug``. A materially different feature set or
+            architecture should use a new ``config_slug`` and start at v1.
+        schema_version: registry schema directory name (default ``"v2"``)
+        overwrite: if False (default), raise ``FileExistsError`` when the
+            target directory already contains a saved model. If True, the
+            existing files are replaced.
+
+    Returns:
+        The ``ModelId`` that was written. Its ``to_path()`` matches what
+        ``LocalRegistry.load()`` expects.
+
+    Raises:
+        FileExistsError: if ``overwrite`` is False and the target directory
+            already contains a saved model.
+        ValueError: if ``version`` is not a positive integer.
+    """
+    # Local import to avoid a circular import at package load time:
+    # routee.powertrain.registry imports Model from core.model, and core.model
+    # imports from this module.
+    from routee.powertrain.registry.model_id import ModelId
+
+    if version < 1:
+        raise ValueError(f"version must be a positive integer, got {version}")
+
+    config = model.metadata.config
+    model_id = ModelId(
+        make=config.make,
+        model=config.model,
+        year=config.year,
+        config_slug=config_slug,
+        version=version,
+    )
+
+    target_dir = Path(registry_root) / schema_version / model_id.to_path()
+    if target_dir.exists() and any(target_dir.iterdir()) and not overwrite:
+        existing = sorted(p.name for p in target_dir.parent.iterdir() if p.is_dir())
+        raise FileExistsError(
+            f"Registry slot already exists: {target_dir}. "
+            f"Existing versions for this config_slug: {existing}. "
+            "Pass overwrite=True to replace, or bump version."
+        )
+
+    save_model_directory(model, target_dir)
+    return model_id
 
 
 def load_model_directory(path: Union[str, Path]) -> Model:

--- a/tests/test_save_to_registry.py
+++ b/tests/test_save_to_registry.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import math
+import shutil
+from pathlib import Path
+from unittest import TestCase
+
+import pandas as pd
+
+import routee.powertrain as pt
+from routee.powertrain.registry.local import LocalRegistry
+from routee.powertrain.trainers.sklearn_random_forest import (
+    SklearnRandomForestTrainer,
+)
+
+this_dir = Path(__file__).parent
+
+
+class TestSaveToRegistry(TestCase):
+    def setUp(self) -> None:
+        data_path = this_dir / "routee-powertrain-test-data" / "sample_train_data.csv"
+        df = pd.read_csv(data_path)
+        feature_set = pt.FeatureSet(
+            features=[
+                pt.DataColumn(name="speed_mph", units="mph"),
+                pt.DataColumn(name="grade_dec", units="decimal"),
+            ],
+        )
+        config = pt.ModelConfig(
+            vehicle_description="Test Model",
+            powertrain_type=pt.PowertrainType.ICE,
+            feature_set=feature_set,
+            distance=pt.DataColumn(name="miles", units="miles"),
+            target=pt.TargetSet(
+                targets=[
+                    pt.DataColumn(
+                        name="gallons_fastsim",
+                        units="gallons_gasoline",
+                        constraints=pt.Constraints(lower=0.0, upper=100.0),
+                    )
+                ],
+            ),
+            make="Test",
+            model="Sedan",
+            year=2024,
+        )
+        self.df = df
+        self.model = SklearnRandomForestTrainer().train(df, config)
+        self.registry_root = Path("tmp_registry")
+
+    def tearDown(self) -> None:
+        if self.registry_root.exists():
+            shutil.rmtree(self.registry_root)
+
+    def test_save_and_load_round_trip(self) -> None:
+        model_id = self.model.save_to_registry(
+            registry_root=self.registry_root,
+            config_slug="rf_default",
+            version=1,
+        )
+
+        expected_dir = (
+            self.registry_root / "v2" / "test" / "sedan" / "2024" / "rf_default" / "v1"
+        )
+        self.assertTrue(expected_dir.is_dir())
+        self.assertTrue((expected_dir / "metadata.json").exists())
+        self.assertTrue((expected_dir / "model.onnx").exists())
+
+        self.assertEqual(model_id.make, "test")
+        self.assertEqual(model_id.model, "sedan")
+        self.assertEqual(model_id.year, 2024)
+        self.assertEqual(model_id.config_slug, "rf_default")
+        self.assertEqual(model_id.version, 1)
+
+        loaded = LocalRegistry(self.registry_root).load(model_id)
+        before = round(self.model.predict(self.df).gallons_fastsim.sum(), 2)
+        after = round(loaded.predict(self.df).gallons_fastsim.sum(), 2)
+        self.assertTrue(math.isclose(before, after))
+
+    def test_existing_slot_raises_without_overwrite(self) -> None:
+        self.model.save_to_registry(
+            registry_root=self.registry_root,
+            config_slug="rf_default",
+            version=1,
+        )
+        with self.assertRaises(FileExistsError):
+            self.model.save_to_registry(
+                registry_root=self.registry_root,
+                config_slug="rf_default",
+                version=1,
+            )
+
+    def test_overwrite_replaces_existing(self) -> None:
+        self.model.save_to_registry(
+            registry_root=self.registry_root,
+            config_slug="rf_default",
+            version=1,
+        )
+        # Second call with overwrite=True must succeed.
+        model_id = self.model.save_to_registry(
+            registry_root=self.registry_root,
+            config_slug="rf_default",
+            version=1,
+            overwrite=True,
+        )
+        loaded = LocalRegistry(self.registry_root).load(model_id)
+        self.assertIsNotNone(loaded)
+
+    def test_invalid_version_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            self.model.save_to_registry(
+                registry_root=self.registry_root,
+                config_slug="rf_default",
+                version=0,
+            )
+
+    def test_query_finds_published_model(self) -> None:
+        self.model.save_to_registry(
+            registry_root=self.registry_root,
+            config_slug="rf_default",
+            version=1,
+        )
+        infos = LocalRegistry(self.registry_root).query(make="test", model="sedan")
+        self.assertEqual(len(infos), 1)
+        self.assertEqual(infos[0].model_id.config_slug, "rf_default")


### PR DESCRIPTION
Adds a model level helper to save a model to a registry with the fixed schema. This is useful for someone who is training models for our model library and need an easy way to save the models into our fixed schema.