### PR TITLE
Add onnxruntime Session Options

### DIFF
--- a/routee/powertrain/estimators/onnx.py
+++ b/routee/powertrain/estimators/onnx.py
@@ -119,7 +119,7 @@ class ONNXEstimator(Estimator):
     ) -> None:
         self.onnx_model = onnx_model
         sess_options = rt.SessionOptions()
-        try: 
+        try:
             num_threads = len(os.sched_getaffinity(0))
         except AttributeError:
             num_threads = os.cpu_count() or 1
@@ -127,7 +127,7 @@ class ONNXEstimator(Estimator):
         self.session = rt.InferenceSession(
             onnx_model.SerializeToString(),
             sess_options=sess_options,
-            providers=["CPUExecutionProvider"]
+            providers=["CPUExecutionProvider"],
         )
         self._input_spec = input_spec
 

--- a/routee/powertrain/estimators/onnx.py
+++ b/routee/powertrain/estimators/onnx.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import os
 from pathlib import Path
 from typing import Literal, Optional, cast
 
@@ -16,6 +15,7 @@ from routee.powertrain.estimators.estimator_interface import (
     InputSpec,
     PadStrategy,
 )
+from routee.powertrain.utils.threading import get_restricted_threads
 
 ONNX_INPUT_NAME = "input"
 ONNX_DTYPE = "float32"
@@ -119,11 +119,9 @@ class ONNXEstimator(Estimator):
     ) -> None:
         self.onnx_model = onnx_model
         sess_options = rt.SessionOptions()
-        try:
-            num_threads = len(os.sched_getaffinity(0))
-        except AttributeError:
-            num_threads = os.cpu_count() or 1
-        sess_options.intra_op_num_threads = num_threads
+        restricted_threads = get_restricted_threads()
+        if restricted_threads is not None:
+            sess_options.intra_op_num_threads = restricted_threads
         self.session = rt.InferenceSession(
             onnx_model.SerializeToString(),
             sess_options=sess_options,

--- a/routee/powertrain/estimators/onnx.py
+++ b/routee/powertrain/estimators/onnx.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import os
 from pathlib import Path
 from typing import Literal, Optional, cast
 
@@ -117,8 +118,16 @@ class ONNXEstimator(Estimator):
         input_spec: InputSpec = InputSpec(),
     ) -> None:
         self.onnx_model = onnx_model
+        sess_options = rt.SessionOptions()
+        try: 
+            num_threads = len(os.sched_getaffinity(0))
+        except AttributeError:
+            num_threads = os.cpu_count() or 1
+        sess_options.intra_op_num_threads = num_threads
         self.session = rt.InferenceSession(
-            onnx_model.SerializeToString(), providers=["CPUExecutionProvider"]
+            onnx_model.SerializeToString(),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"]
         )
         self._input_spec = input_spec
 

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import Literal
 
@@ -14,6 +13,7 @@ from routee.powertrain.core.model_config import ModelConfig
 from routee.powertrain.estimators.estimator_interface import Estimator, InputSpec
 from routee.powertrain.estimators.onnx import ONNX_INPUT_NAME, ONNXEstimator
 from routee.powertrain.trainers.trainer import Trainer
+from routee.powertrain.utils.threading import get_restricted_threads
 
 log = logging.getLogger(__name__)
 
@@ -279,11 +279,9 @@ class CNNTrainer(Trainer):
             torch_out = model(torch.from_numpy(sanity_x)).cpu().numpy()
 
         sess_options = rt.SessionOptions()
-        try:
-            num_threads = len(os.sched_getaffinity(0))
-        except AttributeError:
-            num_threads = os.cpu_count() or 1
-        sess_options.intra_op_num_threads = num_threads
+        restricted_threads = get_restricted_threads()
+        if restricted_threads is not None:
+            sess_options.intra_op_num_threads = restricted_threads
         onnx_sess = rt.InferenceSession(
             onnx_proto.SerializeToString(),
             sess_options=sess_options,

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -279,7 +279,7 @@ class CNNTrainer(Trainer):
             torch_out = model(torch.from_numpy(sanity_x)).cpu().numpy()
 
         sess_options = rt.SessionOptions()
-        try: 
+        try:
             num_threads = len(os.sched_getaffinity(0))
         except AttributeError:
             num_threads = os.cpu_count() or 1
@@ -287,7 +287,7 @@ class CNNTrainer(Trainer):
         onnx_sess = rt.InferenceSession(
             onnx_proto.SerializeToString(),
             sess_options=sess_options,
-            providers=["CPUExecutionProvider"]
+            providers=["CPUExecutionProvider"],
         )
         onnx_out = onnx_sess.run(None, {ONNX_INPUT_NAME: sanity_x})[0]
         max_abs = float(np.max(np.abs(torch_out - onnx_out)))

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import Literal
 
@@ -276,8 +277,17 @@ class CNNTrainer(Trainer):
         )
         with torch.no_grad():
             torch_out = model(torch.from_numpy(sanity_x)).cpu().numpy()
+
+        sess_options = rt.SessionOptions()
+        try: 
+            num_threads = len(os.sched_getaffinity(0))
+        except AttributeError:
+            num_threads = os.cpu_count() or 1
+        sess_options.intra_op_num_threads = num_threads
         onnx_sess = rt.InferenceSession(
-            onnx_proto.SerializeToString(), providers=["CPUExecutionProvider"]
+            onnx_proto.SerializeToString(),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"]
         )
         onnx_out = onnx_sess.run(None, {ONNX_INPUT_NAME: sanity_x})[0]
         max_abs = float(np.max(np.abs(torch_out - onnx_out)))

--- a/routee/powertrain/utils/threading.py
+++ b/routee/powertrain/utils/threading.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+
+
+def get_restricted_threads() -> int | None:
+    """
+    Return the number of restricted threads if in a restricted environment.
+
+    In resource-constrained environments, os.sched_getaffinity may return fewer threads
+    than os.cpu_count. If we detect this restriction, return the restricted count so
+    ONNX respects the environment limit. Otherwise return None to let ONNX use its
+    default behavior.
+    """
+    try:
+        restricted = len(os.sched_getaffinity(0))
+    except AttributeError:
+        return None
+
+    total = os.cpu_count() or 1
+    return restricted if restricted < total else None


### PR DESCRIPTION
# Fix ONNX Runtime Thread Affinity Warnings

## Problem
When running the CNN trainer on Kestrel, onnxruntime emits numerous `pthread_setaffinity_np` warnings while exporting the trained model to ONNX format. For example:
```
[1;31m2026-06-11 08:32:03.771067566 [E:onnxruntime:Default, env.cc:228 ThreadMain] pthread_setaffinity_np failed for thread: 498177, index: 3, mask: {4, }, error code: 22 error msg: Invalid argument. Specify the number of threads explicitly so the affinity is not set.[m
```

These warnings are printed hundreds of times per model export. They do not prevent training from completing or affect the final model, but they are noisy and pollute the output logs. 

## Cause 
ONNX Runtime attempts to manage CPU thread affinity for optimization, but Kestrel won't let it. Specifically, I believe ONNX runtime attempts to manage all the CPUs on the node rather than only the ones assigned to the current job. 

## Solution
When you set `intra_op_num_threads` in `onnxruntime.SessionOptions`, you disable automatic affinity management, preventing these errors while still allowing ONNX runtime to optimize across the specified thread count. In this PR, I updated the runtime to explicitly set this value to the number of cores available. The number of CPUs available is found with `os.sched_getaffinity(0)` with `os.cpu_coun()` used as a fallback for Windows machines. 

## Testing 
With these changes, CNN models train and export without errors both locally (Windows) and on Kestrel. 