### PR TITLE
CNN Trainer Updates

### DIFF
--- a/routee/powertrain/core/model_config.py
+++ b/routee/powertrain/core/model_config.py
@@ -49,7 +49,8 @@ class ModelConfig:
 
     predict_method: PredictMethod = PredictMethod.RATE
 
-    test_size: float = 0.2
+    test_size: Optional[float] = None
+    validation_size: Optional[float] = None
     random_seed: int = 42
 
     trip_column: str = "trip_id"
@@ -96,6 +97,17 @@ class ModelConfig:
 
         if isinstance(self.drivetrain, str):
             self.drivetrain = Drivetrain.from_string(self.drivetrain)
+
+        if self.test_size is not None and not 0 <= self.test_size < 1:
+            raise ValueError("test_size must be in the range [0, 1)")
+        if self.validation_size is not None and not 0 <= self.validation_size < 1:
+            raise ValueError("validation_size must be in the range [0, 1)")
+        if self.test_size is not None and self.validation_size is not None:
+            if self.test_size + self.validation_size >= 1:
+                raise ValueError(
+                    "test_size + validation_size must be less than 1 "
+                    "to leave room for training data"
+                )
 
         # now check all the types
         if not isinstance(self.feature_set, FeatureSet):

--- a/routee/powertrain/estimators/onnx.py
+++ b/routee/powertrain/estimators/onnx.py
@@ -119,7 +119,7 @@ class ONNXEstimator(Estimator):
     ) -> None:
         self.onnx_model = onnx_model
         sess_options = rt.SessionOptions()
-        try: 
+        try:
             num_threads = len(os.sched_getaffinity(0))
         except AttributeError:
             num_threads = os.cpu_count() or 1
@@ -127,7 +127,7 @@ class ONNXEstimator(Estimator):
         self.session = rt.InferenceSession(
             onnx_model.SerializeToString(),
             sess_options=sess_options,
-            providers=["CPUExecutionProvider"]
+            providers=["CPUExecutionProvider"],
         )
         self._input_spec = input_spec
 

--- a/routee/powertrain/estimators/onnx.py
+++ b/routee/powertrain/estimators/onnx.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import os
 from pathlib import Path
 from typing import Literal, Optional, cast
 
@@ -16,6 +15,7 @@ from routee.powertrain.estimators.estimator_interface import (
     InputSpec,
     PadStrategy,
 )
+from routee.powertrain.utils.threading import get_restricted_threads
 
 ONNX_INPUT_NAME = "input"
 ONNX_DTYPE = "float32"
@@ -119,11 +119,9 @@ class ONNXEstimator(Estimator):
     ) -> None:
         self.onnx_model = onnx_model
         sess_options = rt.SessionOptions()
-        try:
-            num_threads = len(os.sched_getaffinity(0))
-        except AttributeError:
-            num_threads = os.cpu_count() or 1
-        sess_options.intra_op_num_threads = num_threads
+        restricted_threads = get_restricted_threads()
+        if restricted_threads is not None:
+            sess_options.intra_op_num_threads = restricted_threads
         self.session = rt.InferenceSession(
             onnx_model.SerializeToString(),
             sess_options=sess_options,

--- a/routee/powertrain/estimators/onnx.py
+++ b/routee/powertrain/estimators/onnx.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import os
 from pathlib import Path
 from typing import Literal, Optional, cast
 
@@ -117,8 +118,16 @@ class ONNXEstimator(Estimator):
         input_spec: InputSpec = InputSpec(),
     ) -> None:
         self.onnx_model = onnx_model
+        sess_options = rt.SessionOptions()
+        try: 
+            num_threads = len(os.sched_getaffinity(0))
+        except AttributeError:
+            num_threads = os.cpu_count() or 1
+        sess_options.intra_op_num_threads = num_threads
         self.session = rt.InferenceSession(
-            onnx_model.SerializeToString(), providers=["CPUExecutionProvider"]
+            onnx_model.SerializeToString(),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"]
         )
         self._input_spec = input_spec
 

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -234,8 +234,10 @@ class CNNTrainer(Trainer):
                     start_factor=1e-8,
                     total_iters=warmup_steps,
                 )
-                scheduler = torch.optim.lr_scheduler.ChainedScheduler(
-                    [warmup_scheduler, cosine_scheduler]
+                scheduler = torch.optim.lr_scheduler.SequentialLR(
+                    optimizer,
+                    schedulers=[warmup_scheduler, cosine_scheduler],
+                    milestones=[warmup_steps],
                 )
             else:
                 scheduler = cosine_scheduler

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -46,6 +46,8 @@ class CNNTrainer(Trainer):
     """
 
     architecture_tag: str = "cnn"
+    default_test_size: float = 0.1
+    default_validation_size: float = 0.1
 
     @property
     def required_extra_columns(self):
@@ -104,8 +106,8 @@ class CNNTrainer(Trainer):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
-        test_features: pd.DataFrame | None = None,
-        test_target: pd.DataFrame | None = None,
+        validation_features: pd.DataFrame | None = None,
+        validation_target: pd.DataFrame | None = None,
     ) -> Estimator:
         try:
             import torch
@@ -175,17 +177,21 @@ class CNNTrainer(Trainer):
         y_cpu = torch.from_numpy(y_matrix)
         X_val_cpu: torch.Tensor | None = None
         y_val_cpu: torch.Tensor | None = None
-        if test_features is not None and test_target is not None:
-            if self.grouping_column not in test_features.columns:
+        if validation_features is not None and validation_target is not None:
+            if self.grouping_column not in validation_features.columns:
                 raise ValueError(
                     f"CNNTrainer requires a '{self.grouping_column}' column in the "
                     f"validation features so windows can be built per route."
                 )
-            test_matrix = test_features[feature_cols].to_numpy(dtype=np.float32)
-            y_val_matrix = test_target.to_numpy(dtype=np.float32)
+            validation_matrix = validation_features[feature_cols].to_numpy(
+                dtype=np.float32
+            )
+            y_val_matrix = validation_target.to_numpy(dtype=np.float32)
             if y_val_matrix.ndim == 1:
                 y_val_matrix = y_val_matrix.reshape(-1, 1)
-            X_val_cpu = torch.from_numpy(_build_windows(test_features, test_matrix))
+            X_val_cpu = torch.from_numpy(
+                _build_windows(validation_features, validation_matrix)
+            )
             y_val_cpu = torch.from_numpy(y_val_matrix)
 
         n_train = X_cpu.shape[0]

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -74,6 +74,7 @@ class CNNTrainer(Trainer):
         device: str | None = None,
         early_stopping_patience: int | None = None,
         early_stopping_min_delta: float = 1e-6,
+        warmup_epochs: int = 0,
     ):
         self.lookback = lookback
         self.grouping_column = grouping_column
@@ -96,6 +97,7 @@ class CNNTrainer(Trainer):
         self.device = device
         self.early_stopping_patience = early_stopping_patience
         self.early_stopping_min_delta = early_stopping_min_delta
+        self.warmup_epochs = warmup_epochs
 
     def inner_train(
         self,
@@ -213,12 +215,25 @@ class CNNTrainer(Trainer):
                 weight_decay=self.weight_decay,
             )
             steps_per_epoch = max(1, (n_train + self.batch_size - 1) // self.batch_size)
-            total_steps = max(1, steps_per_epoch * self.epochs)
-            scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            warmup_steps = self.warmup_epochs * steps_per_epoch
+            cosine_epochs = max(1, self.epochs - self.warmup_epochs)
+            cosine_steps = max(1, cosine_epochs * steps_per_epoch)
+            cosine_scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
                 optimizer,
-                T_max=total_steps,
+                T_max=cosine_steps,
                 eta_min=self.min_learning_rate,
             )
+            if warmup_steps > 0:
+                warmup_scheduler = torch.optim.lr_scheduler.LinearLR(
+                    optimizer,
+                    start_factor=1e-8,
+                    total_iters=warmup_steps,
+                )
+                scheduler = torch.optim.lr_scheduler.ChainedScheduler(
+                    [warmup_scheduler, cosine_scheduler]
+                )
+            else:
+                scheduler = cosine_scheduler
             loss_fn = nn.MSELoss()
             m.train()
             log.info(

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -72,6 +72,8 @@ class CNNTrainer(Trainer):
         normalize_features: bool = True,
         random_seed: int = 52,
         device: str | None = None,
+        early_stopping_patience: int | None = None,
+        early_stopping_min_delta: float = 1e-6,
     ):
         self.lookback = lookback
         self.grouping_column = grouping_column
@@ -92,6 +94,8 @@ class CNNTrainer(Trainer):
         self.normalize_features = normalize_features
         self.random_seed = random_seed
         self.device = device
+        self.early_stopping_patience = early_stopping_patience
+        self.early_stopping_min_delta = early_stopping_min_delta
 
     def inner_train(
         self,
@@ -226,6 +230,10 @@ class CNNTrainer(Trainer):
                 self.n_conv_layers,
             )
             rng = np.random.default_rng(self.random_seed)
+            best_val_loss = float("inf")
+            best_state: dict | None = None
+            patience_counter = 0
+            stopped_early = False
             for epoch_idx in range(self.epochs):
                 epoch_start = time.time()
                 perm = torch.from_numpy(rng.permutation(n_train)).to(dev)
@@ -254,6 +262,23 @@ class CNNTrainer(Trainer):
                     with torch.no_grad():
                         val_loss = loss_fn(m(X_val_dev), y_val_dev).item()
                     m.train()
+                    if self.early_stopping_patience is not None:
+                        if val_loss < best_val_loss - self.early_stopping_min_delta:
+                            best_val_loss = val_loss
+                            best_state = {
+                                k: v.clone() for k, v in m.state_dict().items()
+                            }
+                            patience_counter = 0
+                        else:
+                            patience_counter += 1
+                        if patience_counter >= self.early_stopping_patience:
+                            log.info(
+                                "  Early stopping at epoch %d/%d (no improvement for %d epochs)",
+                                epoch_idx + 1,
+                                self.epochs,
+                                self.early_stopping_patience,
+                            )
+                            stopped_early = True
                 log.info(
                     "  epoch %d/%d  loss=%.6f  val_loss=%.6f  lr=%.2e  elapsed=%.1fs",
                     epoch_idx + 1,
@@ -263,6 +288,10 @@ class CNNTrainer(Trainer):
                     optimizer.param_groups[0]["lr"],
                     time.time() - epoch_start,
                 )
+                if stopped_early:
+                    break
+            if best_state is not None:
+                m.load_state_dict(best_state)
             return m
 
         model = _train_on(device)

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import time
 from typing import Literal
 
@@ -14,6 +13,7 @@ from routee.powertrain.core.model_config import ModelConfig
 from routee.powertrain.estimators.estimator_interface import Estimator, InputSpec
 from routee.powertrain.estimators.onnx import ONNX_INPUT_NAME, ONNXEstimator
 from routee.powertrain.trainers.trainer import Trainer
+from routee.powertrain.utils.threading import get_restricted_threads
 
 log = logging.getLogger(__name__)
 
@@ -279,11 +279,9 @@ class CNNTrainer(Trainer):
             torch_out = model(torch.from_numpy(sanity_x)).cpu().numpy()
 
         sess_options = rt.SessionOptions()
-        try:
-            num_threads = len(os.sched_getaffinity(0))
-        except AttributeError:
-            num_threads = os.cpu_count() or 1
-        sess_options.intra_op_num_threads = num_threads
+        restricted_threads = get_restricted_threads()
+        if restricted_threads is not None:
+            sess_options.intra_op_num_threads = restricted_threads
         onnx_sess = rt.InferenceSession(
             onnx_proto.SerializeToString(),
             sess_options=sess_options,

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -279,7 +279,7 @@ class CNNTrainer(Trainer):
             torch_out = model(torch.from_numpy(sanity_x)).cpu().numpy()
 
         sess_options = rt.SessionOptions()
-        try: 
+        try:
             num_threads = len(os.sched_getaffinity(0))
         except AttributeError:
             num_threads = os.cpu_count() or 1
@@ -287,7 +287,7 @@ class CNNTrainer(Trainer):
         onnx_sess = rt.InferenceSession(
             onnx_proto.SerializeToString(),
             sess_options=sess_options,
-            providers=["CPUExecutionProvider"]
+            providers=["CPUExecutionProvider"],
         )
         onnx_out = onnx_sess.run(None, {ONNX_INPUT_NAME: sanity_x})[0]
         max_abs = float(np.max(np.abs(torch_out - onnx_out)))

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -106,7 +106,6 @@ class CNNTrainer(Trainer):
         config: ModelConfig,
         test_features: pd.DataFrame | None = None,
         test_target: pd.DataFrame | None = None,
-        **kwargs: object,
     ) -> Estimator:
         try:
             import torch

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from typing import Literal
 
@@ -276,8 +277,17 @@ class CNNTrainer(Trainer):
         )
         with torch.no_grad():
             torch_out = model(torch.from_numpy(sanity_x)).cpu().numpy()
+
+        sess_options = rt.SessionOptions()
+        try: 
+            num_threads = len(os.sched_getaffinity(0))
+        except AttributeError:
+            num_threads = os.cpu_count() or 1
+        sess_options.intra_op_num_threads = num_threads
         onnx_sess = rt.InferenceSession(
-            onnx_proto.SerializeToString(), providers=["CPUExecutionProvider"]
+            onnx_proto.SerializeToString(),
+            sess_options=sess_options,
+            providers=["CPUExecutionProvider"]
         )
         onnx_out = onnx_sess.run(None, {ONNX_INPUT_NAME: sanity_x})[0]
         max_abs = float(np.max(np.abs(torch_out - onnx_out)))

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -98,6 +98,9 @@ class CNNTrainer(Trainer):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
+        test_features: pd.DataFrame | None = None,
+        test_target: pd.DataFrame | None = None,
+        **kwargs: object,
     ) -> Estimator:
         try:
             import torch
@@ -143,24 +146,43 @@ class CNNTrainer(Trainer):
             feat_mean = np.zeros(n_features, dtype=np.float32)
             feat_std = np.ones(n_features, dtype=np.float32)
 
-        windows = np.zeros((len(features), self.lookback, n_features), dtype=np.float32)
-        groups = features.groupby(self.grouping_column, sort=False).indices
-        for idx_array in groups.values():
-            idx_array = np.asarray(idx_array)
-            group_features = feature_matrix[idx_array]
-            if self.pad_strategy == "repeat_first":
-                pad_row = group_features[:1]
-            else:
-                pad_row = np.zeros((1, n_features), dtype=np.float32)
-            padded = np.concatenate(
-                [np.repeat(pad_row, self.lookback - 1, axis=0), group_features],
-                axis=0,
-            )
-            for i, row_pos in enumerate(idx_array):
-                windows[row_pos] = padded[i : i + self.lookback]
+        def _build_windows(df: pd.DataFrame, matrix: np.ndarray) -> np.ndarray:
+            windows = np.zeros((len(df), self.lookback, n_features), dtype=np.float32)
+            groups = df.groupby(self.grouping_column, sort=False).indices
+            for idx_array in groups.values():
+                idx_array = np.asarray(idx_array)
+                group_features = matrix[idx_array]
+                if self.pad_strategy == "repeat_first":
+                    pad_row = group_features[:1]
+                else:
+                    pad_row = np.zeros((1, n_features), dtype=np.float32)
+                padded = np.concatenate(
+                    [np.repeat(pad_row, self.lookback - 1, axis=0), group_features],
+                    axis=0,
+                )
+                for i, row_pos in enumerate(idx_array):
+                    windows[row_pos] = padded[i : i + self.lookback]
+            return windows
+
+        windows = _build_windows(features, feature_matrix)
 
         X_cpu = torch.from_numpy(windows)
         y_cpu = torch.from_numpy(y_matrix)
+        X_val_cpu: torch.Tensor | None = None
+        y_val_cpu: torch.Tensor | None = None
+        if test_features is not None and test_target is not None:
+            if self.grouping_column not in test_features.columns:
+                raise ValueError(
+                    f"CNNTrainer requires a '{self.grouping_column}' column in the "
+                    f"validation features so windows can be built per route."
+                )
+            test_matrix = test_features[feature_cols].to_numpy(dtype=np.float32)
+            y_val_matrix = test_target.to_numpy(dtype=np.float32)
+            if y_val_matrix.ndim == 1:
+                y_val_matrix = y_val_matrix.reshape(-1, 1)
+            X_val_cpu = torch.from_numpy(_build_windows(test_features, test_matrix))
+            y_val_cpu = torch.from_numpy(y_val_matrix)
+
         n_train = X_cpu.shape[0]
         log.info("CNN training rows: %d", n_train)
 
@@ -169,6 +191,8 @@ class CNNTrainer(Trainer):
             # Move the full training tensors to the target device once.
             X_dev = X_cpu.to(dev)
             y_dev = y_cpu.to(dev)
+            X_val_dev = X_val_cpu.to(dev) if X_val_cpu is not None else None
+            y_val_dev = y_val_cpu.to(dev) if y_val_cpu is not None else None
             m = _CNN1D(
                 n_features=n_features,
                 hidden_channels=self.hidden_channels,
@@ -224,11 +248,18 @@ class CNNTrainer(Trainer):
                     loss_accum += loss.detach()
                     n_batches += 1
                 avg_loss = (loss_accum / max(1, n_batches)).item()
+                val_loss = float("nan")
+                if X_val_dev is not None and y_val_dev is not None:
+                    m.eval()
+                    with torch.no_grad():
+                        val_loss = loss_fn(m(X_val_dev), y_val_dev).item()
+                    m.train()
                 log.info(
-                    "  epoch %d/%d  loss=%.6f  lr=%.2e  elapsed=%.1fs",
+                    "  epoch %d/%d  loss=%.6f  val_loss=%.6f  lr=%.2e  elapsed=%.1fs",
                     epoch_idx + 1,
                     self.epochs,
                     avg_loss,
+                    val_loss,
                     optimizer.param_groups[0]["lr"],
                     time.time() - epoch_start,
                 )

--- a/routee/powertrain/trainers/ngboost_trainer.py
+++ b/routee/powertrain/trainers/ngboost_trainer.py
@@ -31,7 +31,11 @@ class NGBoostTrainer(Trainer):
         self.random_state = random_state
 
     def inner_train(
-        self, features: pd.DataFrame, target: pd.DataFrame, config: ModelConfig
+        self,
+        features: pd.DataFrame,
+        target: pd.DataFrame,
+        config: ModelConfig,
+        **kwargs: object,
     ) -> Estimator:
         """
         Uses a ngboost model to predict the energy rate values

--- a/routee/powertrain/trainers/ngboost_trainer.py
+++ b/routee/powertrain/trainers/ngboost_trainer.py
@@ -35,7 +35,8 @@ class NGBoostTrainer(Trainer):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
-        **kwargs: object,
+        test_features: pd.DataFrame | None = None,
+        test_target: pd.DataFrame | None = None,
     ) -> Estimator:
         """
         Uses a ngboost model to predict the energy rate values

--- a/routee/powertrain/trainers/ngboost_trainer.py
+++ b/routee/powertrain/trainers/ngboost_trainer.py
@@ -35,8 +35,8 @@ class NGBoostTrainer(Trainer):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
-        test_features: pd.DataFrame | None = None,
-        test_target: pd.DataFrame | None = None,
+        validation_features: pd.DataFrame | None = None,
+        validation_target: pd.DataFrame | None = None,
     ) -> Estimator:
         """
         Uses a ngboost model to predict the energy rate values

--- a/routee/powertrain/trainers/sklearn_random_forest.py
+++ b/routee/powertrain/trainers/sklearn_random_forest.py
@@ -40,7 +40,8 @@ class SklearnRandomForestTrainer(Trainer):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
-        **kwargs: object,
+        test_features: pd.DataFrame | None = None,
+        test_target: pd.DataFrame | None = None,
     ) -> Estimator:
         """
         Uses a random forest to predict the energy rate values

--- a/routee/powertrain/trainers/sklearn_random_forest.py
+++ b/routee/powertrain/trainers/sklearn_random_forest.py
@@ -36,7 +36,11 @@ class SklearnRandomForestTrainer(Trainer):
         self.output_type = output_type
 
     def inner_train(
-        self, features: pd.DataFrame, target: pd.DataFrame, config: ModelConfig
+        self,
+        features: pd.DataFrame,
+        target: pd.DataFrame,
+        config: ModelConfig,
+        **kwargs: object,
     ) -> Estimator:
         """
         Uses a random forest to predict the energy rate values

--- a/routee/powertrain/trainers/sklearn_random_forest.py
+++ b/routee/powertrain/trainers/sklearn_random_forest.py
@@ -40,8 +40,8 @@ class SklearnRandomForestTrainer(Trainer):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
-        test_features: pd.DataFrame | None = None,
-        test_target: pd.DataFrame | None = None,
+        validation_features: pd.DataFrame | None = None,
+        validation_target: pd.DataFrame | None = None,
     ) -> Estimator:
         """
         Uses a random forest to predict the energy rate values

--- a/routee/powertrain/trainers/trainer.py
+++ b/routee/powertrain/trainers/trainer.py
@@ -90,8 +90,17 @@ class Trainer(ABC):
             if extra not in name_list:
                 name_list.append(extra)
         sub_features = train[name_list]
+        test_sub_features = test[name_list]
+        if config.predict_method == PredictMethod.RATE:
+            test_target = test[config.target.target_rate_name_list]
+        else:
+            test_target = test[config.target.target_name_list]
         estimator = self.inner_train(
-            features=sub_features, target=target, config=config
+            features=sub_features,
+            target=target,
+            config=config,
+            test_features=test_sub_features,
+            test_target=test_target,
         )
 
         model_errors = compute_errors(test, estimator, config)
@@ -115,6 +124,9 @@ class Trainer(ABC):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
+        test_features: pd.DataFrame | None = None,
+        test_target: pd.DataFrame | None = None,
+        **kwargs: object,
     ) -> Estimator:
         """
         Builds an estimator from the given data.

--- a/routee/powertrain/trainers/trainer.py
+++ b/routee/powertrain/trainers/trainer.py
@@ -22,7 +22,7 @@ class Trainer(ABC):
     #: Coarse architecture family, used in Metadata for registry-level filtering.
     #: Subclasses override (e.g. ``"random_forest"``, ``"cnn"``, ``"ngboost"``).
     architecture_tag: str = "unknown"
-    
+
     #: Default split sizes used when ModelConfig leaves them unspecified.
     default_test_size: float = 0.2
     default_validation_size: float = 0.0

--- a/routee/powertrain/trainers/trainer.py
+++ b/routee/powertrain/trainers/trainer.py
@@ -126,7 +126,6 @@ class Trainer(ABC):
         config: ModelConfig,
         test_features: pd.DataFrame | None = None,
         test_target: pd.DataFrame | None = None,
-        **kwargs: object,
     ) -> Estimator:
         """
         Builds an estimator from the given data.

--- a/routee/powertrain/trainers/trainer.py
+++ b/routee/powertrain/trainers/trainer.py
@@ -10,7 +10,7 @@ from routee.powertrain.core.metadata import Metadata
 from routee.powertrain.core.model import Model
 from routee.powertrain.core.model_config import ModelConfig, PredictMethod
 from routee.powertrain.estimators.estimator_interface import Estimator
-from routee.powertrain.trainers.utils import test_train_split
+from routee.powertrain.trainers.utils import test_train_validation_split
 from routee.powertrain.validation.errors import compute_errors
 
 ENERGY_RATE_NAME = "energy_rate"
@@ -22,6 +22,10 @@ class Trainer(ABC):
     #: Coarse architecture family, used in Metadata for registry-level filtering.
     #: Subclasses override (e.g. ``"random_forest"``, ``"cnn"``, ``"ngboost"``).
     architecture_tag: str = "unknown"
+    
+    #: Default split sizes used when ModelConfig leaves them unspecified.
+    default_test_size: float = 0.2
+    default_validation_size: float = 0.0
 
     @property
     def required_extra_columns(self) -> List[str]:
@@ -54,9 +58,20 @@ class Trainer(ABC):
                 energy_rate_name = f"{energy_target.name}_rate"
                 data[energy_rate_name] = data[energy_target.name] / data[distance_name]
 
-        train, test = test_train_split(
+        effective_test_size = (
+            config.test_size if config.test_size is not None else self.default_test_size
+        )
+        effective_validation_size = (
+            config.validation_size
+            if config.validation_size is not None
+            else self.default_validation_size
+        )
+        use_validation_split = effective_validation_size > 0
+
+        train, validation, test = test_train_validation_split(
             data,
-            test_size=config.test_size,
+            test_size=effective_test_size,
+            validation_size=effective_validation_size,
             seed=config.random_seed,
             grouping_column=self.split_grouping_column,
         )
@@ -90,17 +105,21 @@ class Trainer(ABC):
             if extra not in name_list:
                 name_list.append(extra)
         sub_features = train[name_list]
-        test_sub_features = test[name_list]
-        if config.predict_method == PredictMethod.RATE:
-            test_target = test[config.target.target_rate_name_list]
-        else:
-            test_target = test[config.target.target_name_list]
+        validation_sub_features: pd.DataFrame | None = None
+        validation_target: pd.DataFrame | None = None
+        if use_validation_split and not validation.empty:
+            validation_sub_features = validation[name_list]
+            if config.predict_method == PredictMethod.RATE:
+                validation_target = validation[config.target.target_rate_name_list]
+            else:
+                validation_target = validation[config.target.target_name_list]
+
         estimator = self.inner_train(
             features=sub_features,
             target=target,
             config=config,
-            test_features=test_sub_features,
-            test_target=test_target,
+            validation_features=validation_sub_features,
+            validation_target=validation_target,
         )
 
         model_errors = compute_errors(test, estimator, config)
@@ -124,8 +143,8 @@ class Trainer(ABC):
         features: pd.DataFrame,
         target: pd.DataFrame,
         config: ModelConfig,
-        test_features: pd.DataFrame | None = None,
-        test_target: pd.DataFrame | None = None,
+        validation_features: pd.DataFrame | None = None,
+        validation_target: pd.DataFrame | None = None,
     ) -> Estimator:
         """
         Builds an estimator from the given data.

--- a/routee/powertrain/trainers/utils.py
+++ b/routee/powertrain/trainers/utils.py
@@ -4,31 +4,53 @@ import numpy as np
 import pandas as pd
 
 
-def test_train_split(
+def test_train_validation_split(
     df: pd.DataFrame,
-    test_size: float = 0.2,
+    test_size: float = 0.1,
+    validation_size: float = 0.1,
     seed: int = 123,
     grouping_column: str | None = None,
 ):
     """
-    Split a dataframe into training and testing sets.
+    Split a dataframe into testing, training, and validation sets.
 
     When ``grouping_column`` is provided, the split operates on unique values
     of that column so that every row belonging to a given group lands
-    entirely in train or entirely in test. This is required for sequence
+    entirely in test, training, or validation. This is required for sequence
     models whose inputs are built from consecutive rows of the same group
     (e.g. the 1D CNN's per-route lookback windows) — a plain row-level split
     would leave each group with gapped rows and destroy the sequence.
+
+    Returns a tuple of three dataframes: (train, validation, test).
     """
+    if not 0 <= test_size < 1:
+        raise ValueError("test_size must be in the range [0, 1)")
+    if not 0 <= validation_size < 1:
+        raise ValueError("validation_size must be in the range [0, 1)")
+    if test_size + validation_size >= 1:
+        raise ValueError(
+            "test_size + validation_size must be less than 1 "
+            "to leave room for training data"
+        )
+
     np.random.seed(seed)
+    train_size = 1 - test_size - validation_size
+
     if grouping_column is None:
-        mask = np.random.rand(len(df)) < (1 - test_size)
+        draw = np.random.rand(len(df))
+        train_mask = draw < train_size
+        val_mask = (draw >= train_size) & (draw < train_size + validation_size)
     else:
         unique_groups = df[grouping_column].unique()
         shuffled = np.random.permutation(unique_groups)
-        n_train = int(round(len(shuffled) * (1 - test_size)))
+        n_train = int(round(len(shuffled) * train_size))
+        n_val = int(round(len(shuffled) * validation_size))
         train_groups = set(shuffled[:n_train].tolist())
-        mask = df[grouping_column].isin(train_groups).to_numpy()
-    train_df = df[mask]
-    test_df = df[~mask]
-    return train_df, test_df
+        val_groups = set(shuffled[n_train : n_train + n_val].tolist())
+        train_mask = df[grouping_column].isin(train_groups).to_numpy()
+        val_mask = df[grouping_column].isin(val_groups).to_numpy()
+
+    train_df = df[train_mask]
+    val_df = df[val_mask]
+    test_df = df[~(train_mask | val_mask)]
+    return train_df, val_df, test_df

--- a/routee/powertrain/utils/threading.py
+++ b/routee/powertrain/utils/threading.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+
+
+def get_restricted_threads() -> int | None:
+    """
+    Return the number of restricted threads if in a restricted environment.
+
+    In resource-constrained environments, os.sched_getaffinity may return fewer threads
+    than os.cpu_count. If we detect this restriction, return the restricted count so
+    ONNX respects the environment limit. Otherwise return None to let ONNX use its
+    default behavior.
+    """
+    try:
+        restricted = len(os.sched_getaffinity(0))
+    except AttributeError:
+        return None
+
+    total = os.cpu_count() or 1
+    return restricted if restricted < total else None


### PR DESCRIPTION
# Summary
This PR implements three improvements to the CNN trainer:
1. Exposes validation loss
2. Adds early stopping criteria
3. Adds warmup to the LR schedule

These changes make the trainer more understandable, reduce overfitting risk, and make optimization more stable across hyperparameter settings.

# 1. Expose Validation Loss
The CNN trainer now computes and logs the validation loss in addition to training loss each epoch.

## What changed
- The trainer base class in `trainer.py` now passes held-out test data (from test-train split) into `inner_train`.
- The CNN trainer logs both training loss and validation loss each epoch.
- Other trainer implementations have been edited to cleanly accept the test data for interface compatibility but currently do not use it.

## Why
- Allows us to check if training and validation loss are trending together or diverging. 
- Enables earlier detection of overfitting.
- Provides the signal used for early stopping criteria.

# 2. Early Stopping Criteria
The CNN trainer now has optional early stopping based on the validation loss curve. Early stopping is off by default.

## New parameters
- `early_stopping_patience` (default `None`)
- `early_stopping_min_delta` (default `1e-6`)

## Behavior
When early stopping is enabled (stopping patience is not None), the Trainer:
- Tracks best validation loss.
- Saves the best model weights when the validation loss improves by more than `early_stopping_min_delta`.
- Stops when the validation loss does not improve for `early_stopping_patience` epochs.
- Restores the best model weights before returning.

## Why
Using early stopping:
- Prevents computational waste
- Prevents overfitting

# 3. LR Schedule Warmup
The CNN trainer now supports an optional LR warmup phase before cosine annealing. Warmup is off by default.

## New parameters
- `warmup_epochs` (default `0`)

## Behavior
- If `warmup_epochs > 0`, training uses linear warmup first, then cosine annealing.
- If `warmup_epochs = 0`, training uses cosine annealing only.

## Why
LR Warmup improves performance and makes hyperparameter tuning more robust. For reference, see the following: 
Kalra, Dayal Singh, and Maissam Barkeshli. _Why Warmup the Learning Rate? Underlying Mechanisms and Improvements._ November 1, 2024. https://doi.org/10.48550/arXiv.2406.09405.