### PR TITLE
CNN Export Drift Check Update

### DIFF
--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -372,10 +372,22 @@ class CNNTrainer(Trainer):
             providers=["CPUExecutionProvider"],
         )
         onnx_out = onnx_sess.run(None, {ONNX_INPUT_NAME: sanity_x})[0]
-        max_abs = float(np.max(np.abs(torch_out - onnx_out)))
-        if max_abs > 1e-4:
+        export_drift_rtol = 1e-3
+        export_drift_atol = 5e-4
+        if not np.allclose(
+            onnx_out,
+            torch_out,
+            rtol=export_drift_rtol,
+            atol=export_drift_atol,
+        ):
+            abs_diff = np.abs(torch_out - onnx_out)
+            max_abs = float(np.max(abs_diff))
+            scale = np.maximum(np.abs(torch_out), np.abs(onnx_out))
+            max_rel = float(np.max(abs_diff / np.maximum(scale, export_drift_atol)))
             raise RuntimeError(
-                f"ONNX export drift exceeded tolerance: max|Δ|={max_abs:.2e}"
+                "ONNX export drift exceeded tolerance: "
+                f"max|Δ|={max_abs:.2e}, max relative drift={max_rel:.2e}, "
+                f"rtol={export_drift_rtol:.1e}, atol={export_drift_atol:.1e}"
             )
 
         return ONNXEstimator(

--- a/routee/powertrain/trainers/cnn.py
+++ b/routee/powertrain/trainers/cnn.py
@@ -373,7 +373,7 @@ class CNNTrainer(Trainer):
         )
         onnx_out = onnx_sess.run(None, {ONNX_INPUT_NAME: sanity_x})[0]
         export_drift_rtol = 1e-3
-        export_drift_atol = 5e-4
+        export_drift_atol = 1e-4
         if not np.allclose(
             onnx_out,
             torch_out,


### PR DESCRIPTION
Updates the export drift check in the CNN trainer to use `np.allclose()`rather than relying purely on element-wise absolute difference.

`np.allclose()` checks element-wise that the following equation is true:
$$|a - b| <= (atol + rtol * |b|)$$

Note that this equation is not symmetric between the inputs $a$ and $b$ but instead uses the second input as the ground-truth reference scale. Due to this, we input the torch output second as it is the original, true output.

For $|b|$ near zero, atol dominates the check, providing an absolute floor matching the previous performance check value of 1e-4. For larger values of $|b|$, rtol dominates, checking that the relative difference between the elements is less than 0.1%.